### PR TITLE
CLI: Python3 is mandatory

### DIFF
--- a/cli/orthos-cli.py
+++ b/cli/orthos-cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Author Jan Löser <jloeser@suse.de>


### PR DESCRIPTION
Python2 doesn't understand `print(..., end=...)`.