### PR TITLE
Fix failing tests

### DIFF
--- a/orthos2/frontend/tests/fixtures/serverconfigs.json
+++ b/orthos2/frontend/tests/fixtures/serverconfigs.json
@@ -25,5 +25,14 @@
       "value": "",
       "created": "2016-01-01T10:00:00+00:00"
     }
+  },
+  {
+    "model": "data.serverconfig",
+    "pk": 30,
+    "fields": {
+      "key": "mail.validdomains",
+      "value": "example.de, example.com, foo.bar",
+      "created": "2016-01-01T10:00:00+00:00"
+    }
   }
 ]

--- a/orthos2/frontend/views.py
+++ b/orthos2/frontend/views.py
@@ -895,7 +895,7 @@ def login(request, template_name='registration/login.html',
                 user = User.objects.get(username=request.POST['username'])
                 if user.is_active and not user.password:
                     messages.info(request, "Please receive your inital password.")
-                    url = reverse('password_restore')
+                    url = reverse('frontend:password_restore')
                     return redirect('{}?user_id={}'.format(url, user.pk))
             except Exception:
                 pass


### PR DESCRIPTION
test_successful_user_creation:

Test mail TLD "foo.bar" must be allowed in 'mail.validdomains' server
configuration key.

test_login_with_password_free_user:

Use correct app name as prefix for reverse URL.