### PR TITLE
Use 'default.log' in current directory

### DIFF
--- a/docs/adminguide/setup.md
+++ b/docs/adminguide/setup.md
@@ -34,14 +34,7 @@
     $ cd orthos2/
     ```
 
-5. Create the log file:
-    ```sh
-    $ sudo mkdir -p /var/log/orthos2
-    $ sudo touch /var/log/orthos2/default.log
-    $ sudo chmod o+w /var/log/orthos2/default.log
-    ```
-
-6. Migrate (create) the database:
+5. Migrate (create) the database:
     ```sh
     $ python manage.py migrate
     Operations to perform:
@@ -50,7 +43,7 @@
             Applying ...
     ```
 
-7. Load initial data:
+6. Load initial data:
     ```sh
     $ python manage.py loaddata data/fixtures/*.json
     Installed 94 object(s) from 7 fixture(s)
@@ -58,7 +51,7 @@
     Installed 2 object(s) from 1 fixture(s)
     ```
 
-8. Create a superuser (administrator) account:
+7. Create a superuser (administrator) account:
     ```sh
     $ python manage.py createsuperuser
     Username (leave blank to use '<your_login>'): admin
@@ -68,7 +61,7 @@
     Superuser created successfully.
     ```
 
-9. Run the test server:
+8. Run the test server:
     ```sh
     $ python manage.py runserver localhost:8000
     Performing system checks...
@@ -79,6 +72,6 @@
     Quit the server with CONTROL-C.
     ```
 
-10. Open your browser and go to [http://localhost:8000](http://localhost:8000) or [http://localhost:8000/admin](http://localhost:8000/admin) (use the superuser login here)
+9. Open your browser and go to [http://localhost:8000](http://localhost:8000) or [http://localhost:8000/admin](http://localhost:8000/admin) (use the superuser login here)
 
 ## Initial setup (production)

--- a/orthos2/orthos2/settings.py
+++ b/orthos2/orthos2/settings.py
@@ -174,7 +174,7 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
             'formatter': 'syslog',
-            'filename': '/var/log/orthos2/default.log',
+            'filename': 'default.log',
         },
     },
     'loggers': {


### PR DESCRIPTION
Developers shouldn't not be compelled to touch the system outside of
this git repository.

If they want, they can still do it.