### PR TITLE
Add __init__ method for MachineSerializer

### DIFF
--- a/orthos2/api/serializers/machine.py
+++ b/orthos2/api/serializers/machine.py
@@ -148,6 +148,11 @@ class MachineSerializer(serializers.ModelSerializer):
 
     group = serializers.CharField(source='group.name')
 
+    def __init__(self, machine, *args, **kwargs):
+        super(MachineSerializer, self).__init__(machine, *args, **kwargs)
+        if  not hasattr(machine, 'group') or not machine.group:
+            self.fields.pop('group')
+
     @property
     def data_info(self):
         result = {}


### PR DESCRIPTION
not every machine is a member of a group, therefore serialization
has to work even when the group field is missing.
This newly created init method removes the group field from the
serializer, if the machine does not contain it.