### PR TITLE
Split up job; Add caching; Run on every push, pull request

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,10 +1,6 @@
 name: Django CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -3,14 +3,12 @@ name: Django CI
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8]
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -19,10 +17,34 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: install pycodestyle
       run: |
+        python -m pip install --upgrade pip
         python -m pip install pycodestyle
     - name: run pycodestyle
       run: |
         pycodestyle .
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        # This path is specific to Ubuntu
+        path: ~/.cache/pip
+        # Look to see if there is a cache hit for the corresponding requirements file
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
     - name: Install Dependencies
       run: |
         sudo apt-get install libldap2-dev libsasl2-dev

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -41,7 +41,7 @@ jobs:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
         # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements-devel.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-


### PR DESCRIPTION
This modifies the workflow so it runs on every push and pull request, not only if those actions are done on master. This helps with debugging before creating a PR.

Additionally, it caches the installed python requirements, so future workflows run faster.

It also separates the lint job from the rest, as this makes it easier to check if both the code uses the correct code style and builds.