### PR TITLE
Handle empty list of valid domain endings

### DIFF
--- a/docs/adminguide/server_configuration.rst
+++ b/docs/adminguide/server_configuration.rst
@@ -101,6 +101,8 @@ Activate/deactivate DHCPv6 server.
 List of valid network domain endings. All FQDN's must match at least one of these.
 Multiple endings can be separated by a comma.
 
+Leave empty if all domains should be accepted.
+
 Default: ``example.de, example.com``
 
 Example: ``example.de, example.com, example.bayern``

--- a/orthos2/utils/misc.py
+++ b/orthos2/utils/misc.py
@@ -127,12 +127,16 @@ def is_dns_resolvable(fqdn):
 
 def has_valid_domain_ending(fqdn, valid_endings):
     """
-    Check if FQDN has valid domain ending.
+    Check if FQDN has valid domain ending. This check can be bypassed if no
+    valid domain endings are given.
 
     Example:
         example.de
         example.com
     """
+    if valid_endings is None:
+        return True
+
     if isinstance(valid_endings, str):
         valid_endings = [valid_endings]
 


### PR DESCRIPTION
Accept all domains by default if no valid domain endings are given in
the server configuration.