### PR TITLE
Allow updating of single machines instead of full cobbler sync

### DIFF
--- a/orthos2/data/signals.py
+++ b/orthos2/data/signals.py
@@ -20,9 +20,9 @@ logger = logging.getLogger('orthos')
 
 
 signal_cobbler_regenerate = Signal(providing_args=['domain_id'])
+signal_cobbler_machine_update = Signal(providing_args=['domain_id', 'machine_id'])
 signal_serialconsole_regenerate = Signal(providing_args=['cscreen_server_fqdn'])
 signal_motd_regenerate = Signal(providing_args=['fqdn'])
-
 
 @receiver(pre_save, sender=Machine)
 def machine_pre_save(sender, instance, *args, **kwargs):
@@ -188,6 +188,17 @@ def regenerate_cobbler(sender, domain_id, *args, **kwargs):
     else:
         task = tasks.RegenerateCobbler(domain_id)
 
+    TaskManager.add(task)
+
+
+@receiver(signal_cobbler_machine_update)
+def update_cobbler_machine(sender, domain_id, machine_id):
+    """
+    Create `RegenerateCobbler()` task here.
+
+    This should be the one and only place for creating this task.
+    """
+    task = tasks.UpdateCobblerMachine(domain_id, machine_id)
     TaskManager.add(task)
 
 

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -188,6 +188,16 @@ class CobblerServer:
 
         self.close()
 
+    def update(self, machine: Machine):
+        self.connect()
+        self._check()
+        command = get_cobbler_update_command(machine, self._cobbler_path)
+        _, stderr, exitcode = self._conn.execute(command)
+        if exitcode:
+            raise CobblerException("Updating {machine} failed with {err}".format(
+                machine.fqdn, stderr))
+
+
     def remove(self, machine: Machine):
         #ToDo: We do not remove machines from cobbler server actively in orthos2 yet
         logging.warning("cobbler remove is switched off")
@@ -273,3 +283,9 @@ class CobblerServer:
                 "Powerswitching of {machine} with {command} failed on {server} with {error}".format(
                     machine=machine.fqdn, command=command, server=self._fqdn))
         return out
+
+    def _check(self):
+        if not self.is_installed():
+            raise CobblerException("No Cobbler service found: {}".format(self._fqdn))
+        if not self.is_running():
+            raise CobblerException("Cobbler server is not running: {}".format(self._fqdn))


### PR DESCRIPTION
Adds the possibility to just use a cobbler system edit command,
instead of a full cobbler sync, controlled by the
"orthos.cobblersync.full" Serverconfig.
This is usefull when orthos2 is not the only data source of the cobbler
server, and greatly reduces overhead for large domains