### PR TITLE
Don't copy hypervisor and bmc to remotepower

### DIFF
--- a/orthos2/api/commands/info.py
+++ b/orthos2/api/commands/info.py
@@ -107,7 +107,6 @@ Example:
             'serial_kernel_device',
             None,
             'power_type',
-            'power_management_bmc',
             'power_host',
             'power_port',
             'power_device',

--- a/orthos2/api/models.py
+++ b/orthos2/api/models.py
@@ -233,15 +233,15 @@ class QueryField:
         },
 
         # RemotePower
-        'rpower_management_bmc': {
-            'field': RemotePower._meta.get_field('management_bmc'),
-            'related_name': 'remotepower',
-            'verbose_name': 'Management BMC',
-            'pre': lambda x:
-                Machine.objects.get(fqdn__iexact=x) if isinstance(x, str) else x,
-            'post': lambda x:
-                Machine.objects.get(pk=x).fqdn
-        },
+       # 'management_bmc': {
+       #     'field': Machine._meta.get_field('management_bmc'),
+       #     'related_name': 'remotepower',
+       #     'verbose_name': 'Management BMC',
+       #     'pre': lambda x:
+       #         Machine.objects.get(fqdn__iexact=x) if isinstance(x, str) else x,
+       #     'post': lambda x:
+       #         Machine.objects.get(pk=x).fqdn
+       # },
         'rpower_power_device': {
             'field': RemotePower._meta.get_field('remote_power_device'),
             'related_name': 'remotepower',

--- a/orthos2/api/serializers/machine.py
+++ b/orthos2/api/serializers/machine.py
@@ -127,7 +127,6 @@ class MachineSerializer(serializers.ModelSerializer):
             'serial_baud_rate',
             'serial_kernel_device',
             'power_type',
-            'power_management_bmc',
             'power_host',
             'power_port',
             'power_comment',
@@ -150,9 +149,7 @@ class MachineSerializer(serializers.ModelSerializer):
     serial_kernel_device = serializers.IntegerField(source='serialconsole.kernel_device')
 
     power_type = serializers.CharField(source='remotepower.fence_name')
-    power_management_bmc = serializers.CharField(
-        source='remotepower.management_bmc'
-    )
+
     power_host = serializers.CharField(source='remotepower.remote_power_device')
     power_port = serializers.CharField(source='remotepower.port')
     power_comment = serializers.CharField(source='remotepower.comment')


### PR DESCRIPTION
Copying this data causes unexpected behaviour, as change to  the machine
admin interface are not propagated to the remotepower without
explicitly saving the remotepower object