### PR TITLE
Don't save the name of users in the database

### DIFF
--- a/orthos2/settings.py
+++ b/orthos2/settings.py
@@ -154,8 +154,6 @@ AUTH_LDAP_USER_SEARCH = LDAPSearch(
 )
 AUTH_LDAP_USER_ATTR_MAP = {
     'username': 'uid',
-    'first_name': 'givenName',
-    'last_name': 'sn',
     'email': 'mail',
 }
 AUTH_LDAP_ALWAYS_UPDATE_USER = True


### PR DESCRIPTION
Saving the names of users is not needed for orthos2 operations,
and therefore a GDPR violation