### PR TITLE
Write SerialConsole data to cobbler

### DIFF
--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -614,6 +614,7 @@ class Machine(models.Model):
                 assert self.architecture == self._original.architecture
                 assert self.group == self._original.group
                 assert self.dhcp_filename == self._original.dhcp_filename
+                assert self.kernel_options == self._original.kernel_options
                 if self.has_remotepower():
                     assert hasattr(self._original, 'remotepower')
                     assert self.remotepower.fence_name == self._original.remotepower.fence_name

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -628,6 +628,11 @@ class Machine(models.Model):
                     assert self.bmc.password == self._original.bmc.password
                     assert self.bmc.mac == self._original.bmc.mac
                     assert self.bmc.fqdn == self._original.bmc.fqdn
+                if self.has_serialconsole():
+                    assert hasattr(self._original, 'serialconsole')
+                    assert self.serialconsole.baud_rate == self._original.serialconsole.baud_rate
+                    assert self.serialconsole.kernel_device_num == \
+                        self._original.serialconsole.kernel_device_num
             except AssertionError:
                 if ServerConfig.objects.bool_by_key("orthos.cobblersync.full"):
                     from orthos2.data.signals import signal_cobbler_regenerate

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -56,6 +56,8 @@ def create_cobbler_options(machine):
             options += " --next-server={server}".format(server=ipv4[0])
     if machine.has_remotepower():
         options += get_power_options(machine)
+    if machine.has_serialconsole():
+        options += get_serial_options(machine)
     return options
 
 
@@ -95,6 +97,11 @@ def get_power_options(machine):
         options += " --power-options={options}".format(options=remotepower.options)
     return options
 
+def get_serial_options(machine):
+    console = machine.SerialConsole
+    options = """ --serial-device="{device}" """.format(device=console.kernel_device_num)
+    options +=  """--serial-baud-rate="{baud}" """.format(baud=console.baud_rate)
+    return options
 
 def get_cobbler_add_command(machine, cobber_path):
     profile = get_default_profile(machine)


### PR DESCRIPTION
The serial baudrate and the kernel device number are needed by cobbler
to generate appropriate kernel options.