### PR TITLE
Set required=False for unknown_mac

### DIFF
--- a/orthos2/api/forms.py
+++ b/orthos2/api/forms.py
@@ -258,7 +258,8 @@ class MachineAPIForm(forms.Form, BaseAPIForm):
 
     unknown_mac = forms.BooleanField(
         label='MAC address currently unknown',
-        initial=False
+        initial=False,
+        required=False
     )
     mac_address = forms.CharField(
         label='MAC address',


### PR DESCRIPTION
For django bool fields this must be set to False, the field can not
be set to false.