### PR TITLE
Fix remotepowerdevice cli

### DIFF
--- a/orthos2/api/commands/__init__.py
+++ b/orthos2/api/commands/__init__.py
@@ -14,7 +14,8 @@ from orthos2.api.commands.add import (AddCommand, AddVMCommand, AddMachineComman
                                       AddRemotePowerCommand, AddBMCCommand,
                                       AddRemotePowerDeviceCommand)
 from orthos2.api.commands.delete import (DeleteCommand, DeleteMachineCommand,
-                                         DeleteSerialConsoleCommand, DeleteRemotePowerCommand)
+                                         DeleteSerialConsoleCommand, DeleteRemotePowerCommand,
+                                         DeleteRemotePowerDeviceCommand)
 
 
 __all__ = [
@@ -38,6 +39,7 @@ __all__ = [
     'DeleteMachineCommand',
     'DeleteSerialConsoleCommand',
     'DeleteRemotePowerCommand',
+    'DeleteRemotePowerDeviceCommand',
     'AddBMCCommand',
     'AddRemotePowerDeviceCommand'
 ]

--- a/orthos2/api/commands/add.py
+++ b/orthos2/api/commands/add.py
@@ -685,7 +685,8 @@ class AddRemotePowerDeviceCommand(BaseAPIView):
             new_device = RemotePowerDevice(username=cleaned_data['username'],
                                            password=cleaned_data['password'],
                                            mac=cleaned_data['mac'],
-                                           fqdn=cleaned_data['fqdn'])
+                                           fqdn=cleaned_data['fqdn'],
+                                           fence_name=cleaned_data['fence_name'])
 
             try:
                 new_device.save()

--- a/orthos2/api/commands/delete.py
+++ b/orthos2/api/commands/delete.py
@@ -47,7 +47,7 @@ Arguments:
                                     (superusers only).
              remotepower        : Delete remote power of a specifc machine
                                     (superusers only).
-             remotepowerdevice  :Delete a remotepower device (superusers only).
+             remotepowerdevice  : Delete a remotepower device (superusers only).
 
 Example:
     DELETE machine

--- a/orthos2/api/commands/delete.py
+++ b/orthos2/api/commands/delete.py
@@ -3,10 +3,10 @@ import logging
 
 from orthos2.api.commands import BaseAPIView, get_machine
 from orthos2.api.forms import (DeleteMachineAPIForm, DeleteRemotePowerAPIForm,
-                               DeleteSerialConsoleAPIForm)
+                               DeleteRemotePowerDeviceAPIForm, DeleteSerialConsoleAPIForm)
 from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
                                           InputSerializer, Message)
-from orthos2.data.models import Machine
+from orthos2.data.models import (Machine, RemotePowerDevice)
 from django.conf.urls import re_path
 from django.contrib.auth.models import AnonymousUser, User
 from django.http import JsonResponse
@@ -20,8 +20,9 @@ class Delete:
     MACHINE = 'machine'
     SERIALCONSOLE = 'serialconsole'
     REMOTEPOWER = 'remotepower'
+    REMOTEPOWERDEVICE = 'remotepowerdevice'
 
-    as_list = [MACHINE, SERIALCONSOLE, REMOTEPOWER]
+    as_list = [MACHINE, SERIALCONSOLE, REMOTEPOWER, REMOTEPOWERDEVICE]
 
 
 class DeleteCommand(BaseAPIView):
@@ -41,11 +42,12 @@ Usage:
 Arguments:
     item - Specify the item which should be deleted. Items are:
 
-             machine       : Delete a machine (superusers only).
-             serialconsole : Delete serial console of a specifc machine
-                             (superusers only).
-             remotepower   : Delete remote power of a specifc machine
-                             (superusers only).
+             machine            : Delete a machine (superusers only).
+             serialconsole      : Delete serial console of a specifc machine
+                                    (superusers only).
+             remotepower        : Delete remote power of a specifc machine
+                                    (superusers only).
+             remotepowerdevice  :Delete a remotepower device (superusers only).
 
 Example:
     DELETE machine
@@ -89,6 +91,12 @@ Example:
                 return ErrorMessage("Invalid number of arguments for 'remotepower'!").as_json
 
             return redirect(reverse('api:remotepower_delete'))
+
+        elif item == Delete.REMOTEPOWERDEVICE:
+            if sub_arguments:
+                return ErrorMessage("Invalid number of arguments for 'remotepowerdevice'!").as_json
+
+            return redirect(reverse('api:remotepowerdevice_delete'))
 
         return ErrorMessage("Unknown item '{}'!".format(item)).as_json
 
@@ -292,6 +300,80 @@ class DeleteRemotePowerCommand(BaseAPIView):
                     return ErrorMessage("Machine has no remote power!").as_json
 
                 result = machine.remotepower.delete()
+
+                theader = [
+                    {'objects': 'Deleted objects'},
+                    {'count': '#'},
+                ]
+
+                response = {
+                    'header': {'type': 'TABLE', 'theader': theader},
+                    'data': [],
+                }
+                for key, value in result[1].items():
+                    response['data'].append(
+                        {
+                            'objects': key.replace('data.', ''),
+                            'count': value
+                        }
+                    )
+                return JsonResponse(response)
+
+            except Exception as e:
+                logger.exception(e)
+                return ErrorMessage("Something went wrong!").as_json
+
+        return ErrorMessage("\n{}".format(format_cli_form_errors(form))).as_json
+
+
+class DeleteRemotePowerDeviceCommand(BaseAPIView):
+
+    URL_POST = '/remotepowerdevice/delete'
+
+    @staticmethod
+    def get_urls():
+        return [
+            re_path(
+                r'^remotepowerdevice/delete',
+                DeleteRemotePowerDeviceCommand.as_view(),
+                name='remotepowerdevice_delete'
+            ),
+        ]
+
+    def get(self, request, *args, **kwargs):
+        """Return form for deleting a remote power."""
+        if isinstance(request.user, AnonymousUser) or not request.auth:
+            return AuthRequiredSerializer().as_json
+
+        if not request.user.is_superuser:
+            return ErrorMessage("Only superusers are allowed to perform this action!").as_json
+
+        form = DeleteRemotePowerDeviceAPIForm()
+
+        input = InputSerializer(
+            form.as_dict(),
+            self.URL_POST,
+            form.get_order()
+        )
+        return input.as_json
+
+    def post(self, request, *args, **kwargs):
+        """Delete remote power."""
+        if not request.user.is_superuser:
+            return ErrorMessage("Only superusers are allowed to perform this action!").as_json
+
+        data = json.loads(request.body.decode('utf-8'))['form']
+        form = DeleteRemotePowerDeviceAPIForm(data)
+
+        if form.is_valid():
+
+            try:
+                cleaned_data = form.cleaned_data
+
+                device = RemotePowerDevice.objects.get(fqdn__iexact=cleaned_data['fqdn'])
+
+
+                result = device.delete()
 
                 theader = [
                     {'objects': 'Deleted objects'},

--- a/orthos2/api/forms.py
+++ b/orthos2/api/forms.py
@@ -2,8 +2,9 @@ import logging
 
 from orthos2.data.models import (Architecture, Enclosure, Machine, MachineGroup,
                                  NetworkInterface, RemotePower, SerialConsole,
-                                 SerialConsoleType, System, is_unique_mac_address,
-                                 validate_dns, validate_mac_address)
+                                 SerialConsoleType, System, RemotePowerDevice,
+                                 is_unique_mac_address, validate_dns,
+                                 validate_mac_address)
 from orthos2.data.models.domain import validate_domain_ending
 from django import forms
 from django.forms.models import ModelChoiceIteratorValue
@@ -548,6 +549,27 @@ class DeleteRemotePowerAPIForm(forms.Form, BaseAPIForm):
     fqdn = forms.CharField(
         label='FQDN',
         max_length=200,
+    )
+
+    def get_order(self):
+        """Return input order."""
+        return [
+            'fqdn',
+        ]
+
+
+class DeleteRemotePowerDeviceAPIForm(forms.Form, BaseAPIForm):
+
+    def clean_fqdn(self):
+        """Check whether `fqdn` already exists."""
+        fqdn = self.cleaned_data['fqdn']
+        if RemotePowerDevice.objects.filter(fqdn__iexact=fqdn).count() == 0:
+            self.add_error('fqdn', "No remotepowerdevice with this FQDN")
+        return fqdn
+
+    fqdn = forms.CharField(
+        label='FQDN',
+        max_length=255,
     )
 
     def get_order(self):

--- a/orthos2/api/models.py
+++ b/orthos2/api/models.py
@@ -224,7 +224,7 @@ class QueryField:
        #     'post': lambda x:
        #         Machine.objects.get(pk=x).fqdn
        # },
-        'rpower_power_device': {
+        'rpower_device': {
             'field': RemotePower._meta.get_field('remote_power_device'),
             'related_name': 'remotepower',
             'verbose_name': 'Remote power device',

--- a/orthos2/api/urls.py
+++ b/orthos2/api/urls.py
@@ -31,3 +31,4 @@ urlpatterns += DeleteCommand.get_urls()                 # noqa: F405
 urlpatterns += DeleteMachineCommand.get_urls()          # noqa: F405
 urlpatterns += DeleteSerialConsoleCommand.get_urls()    # noqa: F405
 urlpatterns += DeleteRemotePowerCommand.get_urls()      # noqa: F405
+urlpatterns += DeleteRemotePowerDeviceCommand.get_urls() # noda: F405


### PR DESCRIPTION
This PR adds a delete command for RemotePowerdevices,
fixes an error where the fence agent did not get saved in the
AddRemotePowerDevice command and renames the
query field from rpower_power_device to rpower_device