### PR TITLE
fix: OBS build in merge requests

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -3,3 +3,4 @@ workflow:
     - branch_package:
         source_project: systemsmanagement:orthos2:github_master_ci
         source_package: orthos2-master
+        target_project: home:trenn


### PR DESCRIPTION
This will (hopefully) fix the missing builds in the OBS when creating a pull request.

See https://openbuildservice.org/2021/09/28/support-for-push-events
