### PR TITLE
Several VM fixes and default value adoptions

### DIFF
--- a/orthos2/data/models/virtualizationapi.py
+++ b/orthos2/data/models/virtualizationapi.py
@@ -234,7 +234,7 @@ class Libvirt(VirtualizationAPI):
         if exitstatus != 0:
             raise Exception(''.join(stderr))
 
-        stdout, stderr, exitstatus = self.conn.execute('brctl show')
+        stdout, stderr, exitstatus = self.conn.execute('bridge vlan')
 
         if exitstatus != 0:
             raise Exception(''.join(stderr))
@@ -353,6 +353,7 @@ class Libvirt(VirtualizationAPI):
         command += '--name {hostname} '
         command += '--vcpus {vcpu} '
         command += '--memory {memory} '
+        command += '--osinfo detect=on,require=off '
 
         disk_ = '--disk {},'.format(kwargs['disk']['image'])
         disk_ += 'size={},'.format(kwargs['disk']['size'])

--- a/orthos2/frontend/forms.py
+++ b/orthos2/frontend/forms.py
@@ -659,15 +659,15 @@ class VirtualMachineForm(forms.Form):
     disk_size = forms.DecimalField(
         label='Disk size (GB)',
         required=True,
-        initial=10,
-        max_value=50,
+        initial=30,
+        max_value=100,
         min_value=10,
-        help_text='Value between 10GB and 50GB; applies only if no image is selected.',
+        help_text='Value between 10GB and 100GB; applies only if no image is selected.',
         widget=forms.NumberInput(attrs={'class': 'form-control'})
     )
 
     vnc = forms.BooleanField(
         label='Enable VNC',
         required=False,
-        initial=True
+        initial=False
     )


### PR DESCRIPTION
- add --osinfo detect=on,require=off to virt-install
- get rid of deprecated "brctl show" command, use "bridge vlan" instead
- 30 GB disk size by default
- vnc off by default