### PR TITLE
fix: Run isort for more idiomatic imports

### DIFF
--- a/ansible/roles/add_custom_facts/files/facts.d/dmesg.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/dmesg.fact
@@ -4,7 +4,6 @@ import json
 import subprocess
 import sys
 
-
 data = dict()
 
 command = "if [ -e /var/log/boot.msg ]; then cat /var/log/boot.msg; else journalctl -xl | head -n200; fi"

--- a/ansible/roles/add_custom_facts/files/facts.d/dmidecode.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/dmidecode.fact
@@ -4,7 +4,6 @@ import json
 import subprocess
 import sys
 
-
 data = dict()
 
 command = ["dmidecode"]

--- a/ansible/roles/add_custom_facts/files/facts.d/hwinfo.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/hwinfo.fact
@@ -4,7 +4,6 @@ import json
 import subprocess
 import sys
 
-
 data = dict()
 
 command = ["hwinfo"]

--- a/ansible/roles/add_custom_facts/files/facts.d/last.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/last.fact
@@ -4,7 +4,6 @@ import json
 import subprocess
 import sys
 
-
 data = dict()
 
 command = "last | grep -v reboot | head -n 1"

--- a/ansible/roles/add_custom_facts/files/facts.d/lsmod.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/lsmod.fact
@@ -4,7 +4,6 @@ import json
 import subprocess
 import sys
 
-
 data = dict()
 
 command = ["lsmod"]

--- a/ansible/roles/add_custom_facts/files/facts.d/lspci.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/lspci.fact
@@ -4,7 +4,6 @@ import json
 import subprocess
 import sys
 
-
 data = dict()
 
 command = ["lspci"]

--- a/ansible/roles/add_custom_facts/files/facts.d/lsscsi.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/lsscsi.fact
@@ -4,7 +4,6 @@ import json
 import subprocess
 import sys
 
-
 data = dict()
 
 command = ["lsscsi", "-s"]

--- a/ansible/roles/add_custom_facts/files/facts.d/lsusb.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/lsusb.fact
@@ -4,7 +4,6 @@ import json
 import subprocess
 import sys
 
-
 data = dict()
 
 command = ["lsusb"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))
 
 

--- a/orthos2/api/commands/__init__.py
+++ b/orthos2/api/commands/__init__.py
@@ -1,22 +1,31 @@
+from orthos2.api.commands.add import (
+    AddAnnotationCommand,
+    AddBMCCommand,
+    AddCommand,
+    AddMachineCommand,
+    AddRemotePowerCommand,
+    AddRemotePowerDeviceCommand,
+    AddSerialConsoleCommand,
+    AddVMCommand,
+)
 from orthos2.api.commands.base import BaseAPIView, get_machine, getException
+from orthos2.api.commands.delete import (
+    DeleteCommand,
+    DeleteMachineCommand,
+    DeleteRemotePowerCommand,
+    DeleteRemotePowerDeviceCommand,
+    DeleteSerialConsoleCommand,
+)
 from orthos2.api.commands.info import InfoCommand
+from orthos2.api.commands.power import PowerCommand
 from orthos2.api.commands.query import QueryCommand
-from orthos2.api.commands.reserve import ReserveCommand
-from orthos2.api.commands.release import ReleaseCommand
-from orthos2.api.commands.reservationhistory import ReservationHistoryCommand
-from orthos2.api.commands.rescan import RescanCommand
 from orthos2.api.commands.regenerate import RegenerateCommand
+from orthos2.api.commands.release import ReleaseCommand
+from orthos2.api.commands.rescan import RescanCommand
+from orthos2.api.commands.reservationhistory import ReservationHistoryCommand
+from orthos2.api.commands.reserve import ReserveCommand
 from orthos2.api.commands.serverconfig import ServerConfigCommand
 from orthos2.api.commands.setup import SetupCommand
-from orthos2.api.commands.power import PowerCommand
-from orthos2.api.commands.add import (AddCommand, AddVMCommand, AddMachineCommand,
-                                      AddSerialConsoleCommand, AddAnnotationCommand,
-                                      AddRemotePowerCommand, AddBMCCommand,
-                                      AddRemotePowerDeviceCommand)
-from orthos2.api.commands.delete import (DeleteCommand, DeleteMachineCommand,
-                                         DeleteSerialConsoleCommand, DeleteRemotePowerCommand,
-                                         DeleteRemotePowerDeviceCommand)
-
 
 __all__ = [
     'InfoCommand',

--- a/orthos2/api/commands/add.py
+++ b/orthos2/api/commands/add.py
@@ -1,20 +1,37 @@
 import json
 import logging
 
-from django.urls import re_path
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import redirect, reverse
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView, get_machine
-from orthos2.api.forms import (AnnotationAPIForm, BMCAPIForm, MachineAPIForm, RemotePowerAPIForm,
-                               RemotePowerDeviceAPIForm, SerialConsoleAPIForm,
-                               VirtualMachineAPIForm)
-from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
-                                          InfoMessage, InputSerializer, Message,
-                                          Serializer)
-from orthos2.data.models import (Annotation, BMC, Machine, RemotePower,
-                                 RemotePowerDevice, SerialConsole)
+from orthos2.api.forms import (
+    AnnotationAPIForm,
+    BMCAPIForm,
+    MachineAPIForm,
+    RemotePowerAPIForm,
+    RemotePowerDeviceAPIForm,
+    SerialConsoleAPIForm,
+    VirtualMachineAPIForm,
+)
+from orthos2.api.serializers.misc import (
+    AuthRequiredSerializer,
+    ErrorMessage,
+    InfoMessage,
+    InputSerializer,
+    Message,
+    Serializer,
+)
+from orthos2.data.models import (
+    BMC,
+    Annotation,
+    Machine,
+    RemotePower,
+    RemotePowerDevice,
+    SerialConsole,
+)
 from orthos2.utils.misc import add_offset_to_date, format_cli_form_errors
 
 logger = logging.getLogger('api')

--- a/orthos2/api/commands/base.py
+++ b/orthos2/api/commands/base.py
@@ -1,5 +1,5 @@
-import sys
 import linecache
+import sys
 
 from django.shortcuts import redirect
 from rest_framework.views import APIView

--- a/orthos2/api/commands/delete.py
+++ b/orthos2/api/commands/delete.py
@@ -1,16 +1,24 @@
 import json
 import logging
 
-from django.urls import re_path
 from django.contrib.auth.models import AnonymousUser
 from django.http import JsonResponse
 from django.shortcuts import redirect, reverse
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView
-from orthos2.api.forms import (DeleteMachineAPIForm, DeleteRemotePowerAPIForm,
-                               DeleteRemotePowerDeviceAPIForm, DeleteSerialConsoleAPIForm)
-from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage, InputSerializer)
-from orthos2.data.models import (Machine, RemotePowerDevice)
+from orthos2.api.forms import (
+    DeleteMachineAPIForm,
+    DeleteRemotePowerAPIForm,
+    DeleteRemotePowerDeviceAPIForm,
+    DeleteSerialConsoleAPIForm,
+)
+from orthos2.api.serializers.misc import (
+    AuthRequiredSerializer,
+    ErrorMessage,
+    InputSerializer,
+)
+from orthos2.data.models import Machine, RemotePowerDevice
 from orthos2.utils.misc import format_cli_form_errors
 
 logger = logging.getLogger('api')

--- a/orthos2/api/commands/info.py
+++ b/orthos2/api/commands/info.py
@@ -1,5 +1,5 @@
-from django.urls import re_path
 from django.http import HttpResponseRedirect, JsonResponse
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView, get_machine, getException
 from orthos2.api.serializers.machine import MachineSerializer

--- a/orthos2/api/commands/power.py
+++ b/orthos2/api/commands/power.py
@@ -1,10 +1,14 @@
-from django.urls import re_path
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
-                                          Message, Serializer)
+from orthos2.api.serializers.misc import (
+    AuthRequiredSerializer,
+    ErrorMessage,
+    Message,
+    Serializer,
+)
 from orthos2.data.models import RemotePower
 
 

--- a/orthos2/api/commands/query.py
+++ b/orthos2/api/commands/query.py
@@ -1,7 +1,7 @@
 import json
 
-from django.urls import re_path
 from django.http import JsonResponse
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView
 from orthos2.api.models import APIQuery

--- a/orthos2/api/commands/regenerate.py
+++ b/orthos2/api/commands/regenerate.py
@@ -1,15 +1,21 @@
-from django.urls import re_path
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
-                                          Message, Serializer)
-from orthos2.data.signals import (signal_cobbler_regenerate,
-                                  signal_serialconsole_regenerate,
-                                  signal_cobbler_machine_update)
-from orthos2.utils.misc import get_hostname, get_domain
+from orthos2.api.serializers.misc import (
+    AuthRequiredSerializer,
+    ErrorMessage,
+    Message,
+    Serializer,
+)
 from orthos2.data.models import Domain, Machine
+from orthos2.data.signals import (
+    signal_cobbler_machine_update,
+    signal_cobbler_regenerate,
+    signal_serialconsole_regenerate,
+)
+from orthos2.utils.misc import get_domain, get_hostname
 
 
 class RegenerateCommand(BaseAPIView):

--- a/orthos2/api/commands/release.py
+++ b/orthos2/api/commands/release.py
@@ -1,10 +1,14 @@
-from django.urls import re_path
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
-                                          Message, Serializer)
+from orthos2.api.serializers.misc import (
+    AuthRequiredSerializer,
+    ErrorMessage,
+    Message,
+    Serializer,
+)
 
 
 class ReleaseCommand(BaseAPIView):

--- a/orthos2/api/commands/rescan.py
+++ b/orthos2/api/commands/rescan.py
@@ -1,10 +1,10 @@
-from django.urls import re_path
 from django.http import HttpResponseRedirect
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView, get_machine
 from orthos2.api.serializers.misc import ErrorMessage, InfoMessage, Message, Serializer
-from orthos2.taskmanager.tasks.machinetasks import MachineCheck
 from orthos2.taskmanager.tasks.daily import DailyMachineChecks
+from orthos2.taskmanager.tasks.machinetasks import MachineCheck
 
 
 class RescanCommand(BaseAPIView):

--- a/orthos2/api/commands/reservationhistory.py
+++ b/orthos2/api/commands/reservationhistory.py
@@ -1,5 +1,5 @@
-from django.urls import re_path
 from django.http import HttpResponseRedirect, JsonResponse
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView, get_machine
 from orthos2.api.serializers.misc import ErrorMessage, InfoMessage, Serializer

--- a/orthos2/api/commands/reserve.py
+++ b/orthos2/api/commands/reserve.py
@@ -1,16 +1,21 @@
 import datetime
 import json
 
-from django.urls import re_path
 from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpResponseRedirect
+from django.urls import re_path
 
-from orthos2.utils.misc import add_offset_to_date, format_cli_form_errors
 from orthos2.api.commands import BaseAPIView, get_machine
 from orthos2.api.forms import ReserveMachineAPIForm
-from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
-                                          InputSerializer, Message, Serializer)
+from orthos2.api.serializers.misc import (
+    AuthRequiredSerializer,
+    ErrorMessage,
+    InputSerializer,
+    Message,
+    Serializer,
+)
 from orthos2.data.models import Machine
+from orthos2.utils.misc import add_offset_to_date, format_cli_form_errors
 
 
 class ReserveCommand(BaseAPIView):

--- a/orthos2/api/commands/serverconfig.py
+++ b/orthos2/api/commands/serverconfig.py
@@ -1,10 +1,13 @@
-from django.urls import re_path
 from django.contrib.auth.models import AnonymousUser
 from django.http import JsonResponse
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView
-from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
-                                          InfoMessage)
+from orthos2.api.serializers.misc import (
+    AuthRequiredSerializer,
+    ErrorMessage,
+    InfoMessage,
+)
 from orthos2.data.models import ServerConfig
 
 

--- a/orthos2/api/commands/setup.py
+++ b/orthos2/api/commands/setup.py
@@ -1,12 +1,17 @@
 import logging
 
-from django.urls import re_path
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect, JsonResponse
+from django.urls import re_path
 
 from orthos2.api.commands import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
-                                          InfoMessage, Message, Serializer)
+from orthos2.api.serializers.misc import (
+    AuthRequiredSerializer,
+    ErrorMessage,
+    InfoMessage,
+    Message,
+    Serializer,
+)
 
 logger = logging.getLogger('api')
 

--- a/orthos2/api/forms.py
+++ b/orthos2/api/forms.py
@@ -1,20 +1,35 @@
 import logging
 
 from django import forms
-from django.forms.models import ModelChoiceIteratorValue
 from django.forms import inlineformset_factory
-from django.forms.fields import (BooleanField, CharField, ChoiceField,
-                                 DateField, DecimalField, IntegerField)
+from django.forms.fields import (
+    BooleanField,
+    CharField,
+    ChoiceField,
+    DateField,
+    DecimalField,
+    IntegerField,
+)
+from django.forms.models import ModelChoiceIteratorValue
 from django.template.defaultfilters import slugify
 
-from orthos2.data.models import (Architecture, Enclosure, Machine, MachineGroup,
-                                 NetworkInterface, RemotePower, SerialConsole,
-                                 System, RemotePowerDevice, SerialConsoleType,
-                                 is_unique_mac_address, validate_dns,
-                                 validate_mac_address)
+from orthos2.data.models import (
+    Architecture,
+    Enclosure,
+    Machine,
+    MachineGroup,
+    NetworkInterface,
+    RemotePower,
+    RemotePowerDevice,
+    SerialConsole,
+    SerialConsoleType,
+    System,
+    is_unique_mac_address,
+    validate_dns,
+    validate_mac_address,
+)
 from orthos2.data.models.domain import validate_domain_ending
 from orthos2.frontend.forms import ReserveMachineForm, VirtualMachineForm
-
 
 logger = logging.getLogger('api')
 

--- a/orthos2/api/models.py
+++ b/orthos2/api/models.py
@@ -1,16 +1,29 @@
 import logging
 import re
 
-from django.core.exceptions import (FieldDoesNotExist,
-                                    MultipleObjectsReturned)
+from django.core.exceptions import FieldDoesNotExist, MultipleObjectsReturned
 from django.db.models import Field, Q
 from django.db.models.functions import Length
 
 from orthos2.api.lookups import NotEqual
-from orthos2.data.models import (Annotation, Architecture, Domain, Enclosure,
-                                 Installation, Machine, MachineGroup, NetworkInterface,
-                                 PCIDevice, Platform, RemotePower, SerialConsole,
-                                 SerialConsoleType, System, User, Vendor)
+from orthos2.data.models import (
+    Annotation,
+    Architecture,
+    Domain,
+    Enclosure,
+    Installation,
+    Machine,
+    MachineGroup,
+    NetworkInterface,
+    PCIDevice,
+    Platform,
+    RemotePower,
+    SerialConsole,
+    SerialConsoleType,
+    System,
+    User,
+    Vendor,
+)
 
 logger = logging.getLogger('api')
 

--- a/orthos2/api/serializers/bmc.py
+++ b/orthos2/api/serializers/bmc.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from orthos2.data.models import BMC
 
 

--- a/orthos2/api/serializers/machine.py
+++ b/orthos2/api/serializers/machine.py
@@ -1,10 +1,11 @@
 from rest_framework import serializers
 
 from orthos2.data.models import Machine
+
 from .annotation import AnnotationSerializer
+from .bmc import BMCSerializer
 from .installation import InstallationSerializer
 from .networkinterface import NetworkInterfaceSerializer
-from .bmc import BMCSerializer
 
 
 class NetworkInterfaceListingField(NetworkInterfaceSerializer):

--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -575,10 +575,10 @@ class DomainAdmin(admin.ModelAdmin):
     inlines = (ArchsInline, )
 
     def cobbler_server_list(self, obj):
-        """Return DHCP server list as string."""
-        if obj.cobbler_server.all().count() == 0:
-            return '-'
-        return ', '.join([cobbler_server.fqdn for cobbler_server in obj.cobbler_server.all()])
+        """Return DHCP server FQDN as string."""
+        cobbler_server = obj.cobbler_server
+        return cobbler_server.fqdn if cobbler_server else '-'
+
 
     def delete_model(self, request, obj=None):
         try:

--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -238,8 +238,6 @@ class MachineAdminForm(forms.ModelForm):
         fqdn = self.cleaned_data['fqdn']
 
         if hasattr(self, 'machine'):
-            if fqdn != self.machine.fqdn:
-                raise ValidationError("Machines must not be renamed. Delete and add them if needed")
             # We do not reach below check, but we do if we would allow renaming at some point
             if Machine.objects.filter(fqdn=fqdn).exclude(pk=self.machine.pk):
                 raise ValidationError("FQDN is already in use!")

--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -1,21 +1,37 @@
 from django import forms
-from django.urls import re_path
 from django.contrib import admin, messages
 from django.contrib.admin.templatetags.admin_list import _boolean_icon
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.shortcuts import redirect
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils.html import format_html
 
-from orthos2.utils.remotepowertype import RemotePowerType
 from orthos2.api.forms import RemotePowerDeviceAPIForm
+from orthos2.utils.remotepowertype import RemotePowerType
 
-from .models import (Annotation, Architecture, BMC, Domain, Enclosure,
-                     Machine, MachineGroup, MachineGroupMembership, DomainAdmin,
-                     NetworkInterface, Platform, RemotePower, RemotePowerDevice,
-                     SerialConsole, SerialConsoleType, ServerConfig, System, Vendor,
-                     is_unique_mac_address, validate_mac_address)
+from .models import (
+    BMC,
+    Annotation,
+    Architecture,
+    Domain,
+    DomainAdmin,
+    Enclosure,
+    Machine,
+    MachineGroup,
+    MachineGroupMembership,
+    NetworkInterface,
+    Platform,
+    RemotePower,
+    RemotePowerDevice,
+    SerialConsole,
+    SerialConsoleType,
+    ServerConfig,
+    System,
+    Vendor,
+    is_unique_mac_address,
+    validate_mac_address,
+)
 
 
 class BMCInlineFormset(forms.models.BaseInlineFormSet):

--- a/orthos2/data/management/commands/dump_db.py
+++ b/orthos2/data/management/commands/dump_db.py
@@ -6,7 +6,7 @@ from django.apps import apps
 from django.core.management.base import BaseCommand
 
 from orthos2.data.models.domain import Domain, DomainAdmin
-from orthos2.data.models.machine import Machine, Enclosure, NetworkInterface
+from orthos2.data.models.machine import Enclosure, Machine, NetworkInterface
 from orthos2.taskmanager.models import DailyTask
 
 USAGE = """

--- a/orthos2/data/management/commands/dump_db.py
+++ b/orthos2/data/management/commands/dump_db.py
@@ -110,8 +110,8 @@ class Command(BaseCommand):
                 self.add_machine(d_obj.tftp_server.fqdn)
             if d_obj.cscreen_server:
                 self.add_machine(d_obj.cscreen_server.fqdn)
-            if d_obj.cobbler_server and len(d_obj.cobbler_server.all()):
-                self.add_machine(d_obj.cobbler_server.all()[0].fqdn)
+            if d_obj.cobbler_server:
+                self.add_machine(d_obj.cobbler_server.fqdn)
 
             query = Domain.objects.filter(name=d_obj)
             self.queries.extend(query)
@@ -135,7 +135,7 @@ class Command(BaseCommand):
         for item in query:
             item.tftp_server = None
             item.cscreen_server = None
-            item.cobbler_server.set([])
+            item.cobbler_server = None
         self.queries.extend(query)
         self.add_machine("markeb.arch.suse.de")
 

--- a/orthos2/data/models/__init__.py
+++ b/orthos2/data/models/__init__.py
@@ -1,20 +1,20 @@
-from .machine import *                      # noqa: F403
-from .enclosure import *                    # noqa: F403
-from .architecture import *                 # noqa: F403
-from .domain import *                       # noqa: F403
-from .platform import *                     # noqa: F403
-from .system import *                       # noqa: F403
-from .serverconfig import *                 # noqa: F403
-from .installation import *                 # noqa: F403
-from .vendor import *                       # noqa: F403
-from .networkinterface import *             # noqa: F403
-from .reservationhistory import *           # noqa: F403
-from .serialconsole import *                # noqa: F403
-from .remotepower import *                  # noqa: F403
-from .machinegroup import MachineGroup, MachineGroupMembership
+from .annotation import Annotation
+from .architecture import *  # noqa: F403
+from .bmc import *  # noqa: F403
 from .component import Component
 from .components.pci import PCIDevice
-from .annotation import Annotation
-from .virtualizationapi import *            # noqa: F403
-from .bmc import *                          # noqa: F403
-from .remotepowerdevice import *            # noqa: F403
+from .domain import *  # noqa: F403
+from .enclosure import *  # noqa: F403
+from .installation import *  # noqa: F403
+from .machine import *  # noqa: F403
+from .machinegroup import MachineGroup, MachineGroupMembership
+from .networkinterface import *  # noqa: F403
+from .platform import *  # noqa: F403
+from .remotepower import *  # noqa: F403
+from .remotepowerdevice import *  # noqa: F403
+from .reservationhistory import *  # noqa: F403
+from .serialconsole import *  # noqa: F403
+from .serverconfig import *  # noqa: F403
+from .system import *  # noqa: F403
+from .vendor import *  # noqa: F403
+from .virtualizationapi import *  # noqa: F403

--- a/orthos2/data/models/bmc.py
+++ b/orthos2/data/models/bmc.py
@@ -1,6 +1,7 @@
 from django.db import models
 
 from orthos2.utils.remotepowertype import get_remote_power_type_choices
+
 from .machine import Machine
 
 

--- a/orthos2/data/models/domain.py
+++ b/orthos2/data/models/domain.py
@@ -35,7 +35,7 @@ class Domain(models.Model):
         validators=[validate_domain_ending]
     )
 
-    cobbler_server = models.ManyToManyField(
+    cobbler_server = models.ForeignKey(
         'data.Machine',
         related_name='cobbler_server_for',
         verbose_name='Cobbler server',

--- a/orthos2/data/models/domain.py
+++ b/orthos2/data/models/domain.py
@@ -4,6 +4,7 @@ import logging
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.template import Context, Template
+
 from orthos2.utils.misc import has_valid_domain_ending
 
 from .architecture import Architecture

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -765,7 +765,7 @@ class Machine(models.Model):
     is_administrative.boolean = True
 
     def is_cobbler_server(self):
-        return self.domain_set.all().exists()
+        return self.cobbler_server_for.exists()
     is_cobbler_server.boolean = True
 
     def is_virtual_machine(self):

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -6,21 +6,27 @@ from copy import deepcopy
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import serializers
-from django.core.exceptions import (PermissionDenied, ValidationError, ObjectDoesNotExist)
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-from orthos2.utils.misc import (Serializer, get_domain, get_hostname,
-                                get_ipv4, get_ipv6, get_s390_hostname,
-                                is_dns_resolvable)
-
 
 from orthos2.data.exceptions import ReleaseException, ReserveException
+from orthos2.utils.misc import (
+    Serializer,
+    get_domain,
+    get_hostname,
+    get_ipv4,
+    get_ipv6,
+    get_s390_hostname,
+    is_dns_resolvable,
+)
+
 from .architecture import Architecture
 from .domain import Domain, DomainAdmin, validate_domain_ending
 from .enclosure import Enclosure
 from .machinegroup import MachineGroup
-from .networkinterface import validate_mac_address, NetworkInterface
+from .networkinterface import NetworkInterface, validate_mac_address
 from .platform import Platform
 from .system import System
 from .virtualizationapi import VirtualizationAPI
@@ -726,6 +732,7 @@ class Machine(models.Model):
                 sender=self.__class__, domain_id=domain_id, machine_id=machine_id)
         if sync_dhcp:
             from orthos2.data.signals import signal_cobbler_sync_dhcp
+
             # regenerate DHCP on all domains (deletion/registration) if domain changed
             domain_id = self.fqdn_domain.pk
             signal_cobbler_sync_dhcp.send(sender=self.__class__, domain_id=domain_id)
@@ -1130,8 +1137,8 @@ class Machine(models.Model):
     def scan(self, action='all', user=None):
         """Start scanning/checking the machine by creating a task."""
         from orthos2.taskmanager import tasks
-        from orthos2.taskmanager.tasks.ansible import Ansible
         from orthos2.taskmanager.models import TaskManager
+        from orthos2.taskmanager.tasks.ansible import Ansible
 
         if action.lower() not in tasks.MachineCheck.Scan.Action.as_list:
             raise Exception("Unknown scan option '{}'!".format(action))

--- a/orthos2/data/models/remotepower.py
+++ b/orthos2/data/models/remotepower.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 
 from orthos2.utils.remotepowertype import RemotePowerType, get_remote_power_type_choices
+
 from . import ServerConfig
 
 

--- a/orthos2/data/models/remotepowerdevice.py
+++ b/orthos2/data/models/remotepowerdevice.py
@@ -1,7 +1,8 @@
-from django.db import models
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import models
 
 from orthos2.utils.remotepowertype import get_remote_power_type_choices
+
 from . import ServerConfig
 
 

--- a/orthos2/data/models/system.py
+++ b/orthos2/data/models/system.py
@@ -1,4 +1,5 @@
 from django.db import models
+
 from orthos2.utils.misc import safe_get_or_default
 
 

--- a/orthos2/data/models/virtualizationapi.py
+++ b/orthos2/data/models/virtualizationapi.py
@@ -80,9 +80,16 @@ class VirtualizationAPI:
         Method returns a new `Machine` object and calls the subclass to actually create the virtual
         machine physically.
         """
-        from orthos2.data.models import (Architecture, Machine, RemotePower,
-                                         SerialConsole, SerialConsoleType, System)
         from django.contrib.auth.models import User
+
+        from orthos2.data.models import (
+            Architecture,
+            Machine,
+            RemotePower,
+            SerialConsole,
+            SerialConsoleType,
+            System,
+        )
 
         vm = Machine()
         vm.unsaved_networkinterfaces = []

--- a/orthos2/data/scripts/dump_test_db.py
+++ b/orthos2/data/scripts/dump_test_db.py
@@ -3,8 +3,9 @@
 import os
 
 from django.apps import apps
+
 from orthos2.data.models.domain import Domain, DomainAdmin
-from orthos2.data.models.machine import Machine, Enclosure, NetworkInterface
+from orthos2.data.models.machine import Enclosure, Machine, NetworkInterface
 from orthos2.taskmanager.models import DailyTask
 
 USAGE = """

--- a/orthos2/data/scripts/dump_test_db.py
+++ b/orthos2/data/scripts/dump_test_db.py
@@ -99,8 +99,8 @@ def add_domain(domain: str, queries: list):
             add_machine(d_obj.tftp_server.fqdn, queries)
         if d_obj.cscreen_server:
             add_machine(d_obj.cscreen_server.fqdn, queries)
-        if d_obj.cobbler_server and len(d_obj.cobbler_server.all()):
-            add_machine(d_obj.cobbler_server.all()[0].fqdn, queries)
+        if d_obj.cobbler_server:
+            add_machine(d_obj.cobbler_server.fqdn, queries)
 
         query = Domain.objects.filter(name=d_obj)
         queries.extend(query)
@@ -109,6 +109,7 @@ def add_domain(domain: str, queries: list):
     except Domain.DoesNotExist:
         print("%s - Domain does not exist" % domain)
         show_help()
+
 
 
 def add_arch_relations(queries: list):

--- a/orthos2/data/signals.py
+++ b/orthos2/data/signals.py
@@ -3,15 +3,28 @@ import os
 import time
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models.signals import (post_delete, post_init, post_save,
-                                      pre_delete, pre_save)
+from django.db.models.signals import (
+    post_delete,
+    post_init,
+    post_save,
+    pre_delete,
+    pre_save,
+)
 from django.dispatch import Signal, receiver
+
 from orthos2.taskmanager import tasks
 from orthos2.taskmanager.models import TaskManager
-from orthos2.utils.misc import (Serializer, get_hostname)
 from orthos2.utils.cobbler import CobblerServer
+from orthos2.utils.misc import Serializer, get_hostname
 
-from .models import (Machine, NetworkInterface, SerialConsole, ServerConfig, is_unique_mac_address)
+from .models import (
+    Machine,
+    NetworkInterface,
+    SerialConsole,
+    ServerConfig,
+    is_unique_mac_address,
+)
+
 logger = logging.getLogger('orthos')
 
 

--- a/orthos2/frontend/ajax.py
+++ b/orthos2/frontend/ajax.py
@@ -4,8 +4,8 @@ from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.template.defaultfilters import urlize
 
-from orthos2.frontend.templatetags.tags import vm_record
 from orthos2.data.models import Annotation, Machine, RemotePower
+from orthos2.frontend.templatetags.tags import vm_record
 
 from .decorators import check_permissions
 

--- a/orthos2/frontend/forms.py
+++ b/orthos2/frontend/forms.py
@@ -8,8 +8,14 @@ from django.contrib.auth.models import User
 from django.utils import timezone
 from django.utils.formats import date_format
 
-from orthos2.data.models import (Installation, Machine, Platform,
-                                 ServerConfig, System, Vendor)
+from orthos2.data.models import (
+    Installation,
+    Machine,
+    Platform,
+    ServerConfig,
+    System,
+    Vendor,
+)
 
 logger = logging.getLogger('views')
 

--- a/orthos2/frontend/management/commands/serialconsole-ws.py
+++ b/orthos2/frontend/management/commands/serialconsole-ws.py
@@ -1,4 +1,5 @@
 import sys
+
 try:
     from ptyprocess import PtyProcessUnicode
     from terminado import TermSocket, UniqueTermManager

--- a/orthos2/frontend/tests/admin/test_machine.py
+++ b/orthos2/frontend/tests/admin/test_machine.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-
 from django_webtest import WebTest
 
 

--- a/orthos2/frontend/tests/admin/test_machine_views.py
+++ b/orthos2/frontend/tests/admin/test_machine_views.py
@@ -1,5 +1,4 @@
 import mock
-
 from django.urls import reverse
 from django_webtest import WebTest
 

--- a/orthos2/frontend/tests/user/test_ldap.py
+++ b/orthos2/frontend/tests/user/test_ldap.py
@@ -6,6 +6,7 @@
 
 from django.urls import reverse
 from django_webtest import WebTest
+
 from orthos2.data.models.serverconfig import ServerConfig
 
 

--- a/orthos2/frontend/tests/user/test_restore_password.py
+++ b/orthos2/frontend/tests/user/test_restore_password.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django_webtest import WebTest
+
 from orthos2.taskmanager.models import SingleTask
 
 

--- a/orthos2/frontend/urls.py
+++ b/orthos2/frontend/urls.py
@@ -1,8 +1,9 @@
-from django.urls import re_path
 from django.contrib.auth import views as auth_views
+from django.urls import re_path
 from django.views.generic import RedirectView
 
 from . import ajax, views
+
 app_name = 'orthos2.frontend'
 urlpatterns = [
     re_path(r'^$', RedirectView.as_view(pattern_name='frontend:free_machines'), name='root'),

--- a/orthos2/frontend/views.py
+++ b/orthos2/frontend/views.py
@@ -25,19 +25,30 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import ListView
-
 from rest_framework.authtoken.models import Token
 
-from orthos2.data.models import (Architecture, Domain, Machine, MachineGroup,
-                                 ReservationHistory, ServerConfig)
+from orthos2.data.models import (
+    Architecture,
+    Domain,
+    Machine,
+    MachineGroup,
+    ReservationHistory,
+    ServerConfig,
+)
 from orthos2.taskmanager import tasks
 from orthos2.taskmanager.models import TaskManager
 from orthos2.utils.misc import add_offset_to_date
 
 from .decorators import check_permissions
-from .forms import (NewUserForm, PasswordRestoreForm, PreferencesForm,
-                    ReserveMachineForm, SearchForm, SetupMachineForm,
-                    VirtualMachineForm)
+from .forms import (
+    NewUserForm,
+    PasswordRestoreForm,
+    PreferencesForm,
+    ReserveMachineForm,
+    SearchForm,
+    SetupMachineForm,
+    VirtualMachineForm,
+)
 
 logger = logging.getLogger('views')
 

--- a/orthos2/settings.py
+++ b/orthos2/settings.py
@@ -14,8 +14,8 @@ import logging
 import logging.config
 import os
 import sys
-from socket import getfqdn, gethostname
 from pwd import getpwuid
+from socket import getfqdn, gethostname
 
 from django.contrib.messages import constants as messages
 

--- a/orthos2/taskmanager/admin.py
+++ b/orthos2/taskmanager/admin.py
@@ -1,9 +1,8 @@
 import datetime
 
-from django.urls import re_path
 from django.contrib import admin, messages
 from django.shortcuts import redirect
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils.html import format_html
 
 from .models import DailyTask, SingleTask

--- a/orthos2/taskmanager/executer.py
+++ b/orthos2/taskmanager/executer.py
@@ -6,14 +6,14 @@ from queue import Empty as queueEmpty
 from queue import Queue
 from threading import Thread
 
-from django.utils import timezone
-from django.db.utils import InterfaceError
 from django import db
+from django.db.utils import InterfaceError
+from django.utils import timezone
 
 from orthos2.data.models import ServerConfig
+
 from . import Priority
 from .models import BaseTask, DailyTask, SingleTask
-
 
 logger = logging.getLogger('tasks')
 

--- a/orthos2/taskmanager/management/commands/taskmanager.py
+++ b/orthos2/taskmanager/management/commands/taskmanager.py
@@ -6,6 +6,7 @@ import sys
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+
 from orthos2.taskmanager.executer import TaskExecuter
 
 logger = logging.getLogger('tasks')

--- a/orthos2/taskmanager/models.py
+++ b/orthos2/taskmanager/models.py
@@ -1,6 +1,5 @@
 import json
 import logging
-
 from hashlib import sha1
 
 from django.db import models

--- a/orthos2/taskmanager/tasks/__init__.py
+++ b/orthos2/taskmanager/tasks/__init__.py
@@ -1,9 +1,16 @@
-from .machinetasks import RegenerateMOTD, MachineCheck
-from .notifications import (CheckReservationExpiration, SendRestoredPassword,
-                            SendReservationInformation, CheckMultipleAccounts,
-                            CheckForPrimaryNetwork)
+from .cobbler import RegenerateCobbler, SyncCobblerDHCP, UpdateCobblerMachine
+from .daily import (
+    DailyCheckForPrimaryNetwork,
+    DailyCheckReservationExpirations,
+    DailyMachineChecks,
+)
+from .machinetasks import MachineCheck, RegenerateMOTD
+from .notifications import (
+    CheckForPrimaryNetwork,
+    CheckMultipleAccounts,
+    CheckReservationExpiration,
+    SendReservationInformation,
+    SendRestoredPassword,
+)
 from .sconsole import RegenerateSerialConsole
-from .cobbler import RegenerateCobbler, UpdateCobblerMachine, SyncCobblerDHCP
-from .daily import (DailyMachineChecks, DailyCheckReservationExpirations,
-                    DailyCheckForPrimaryNetwork)
 from .setup import SetupMachine

--- a/orthos2/taskmanager/tasks/ansible.py
+++ b/orthos2/taskmanager/tasks/ansible.py
@@ -5,20 +5,19 @@ This function/module will replace get_hardware_information by
 passing ansible collected data instead of self called functions
 '''
 
+import glob
+import json
+import logging
 import os
 import shutil
-import glob
 import threading
-import logging
-import json
 from datetime import datetime
 
 from django.template.loader import render_to_string
 
-from orthos2.taskmanager.models import Task
 from orthos2.data.models import Machine
-from orthos2.utils.misc import normalize_ascii
-from orthos2.utils.misc import execute
+from orthos2.taskmanager.models import Task
+from orthos2.utils.misc import execute, normalize_ascii
 
 logger = logging.getLogger('tasks')
 

--- a/orthos2/taskmanager/tasks/machinetasks.py
+++ b/orthos2/taskmanager/tasks/machinetasks.py
@@ -4,9 +4,15 @@ from django.utils import timezone
 
 from orthos2.data.models import Machine, NetworkInterface, ServerConfig
 from orthos2.taskmanager.models import Task
-from orthos2.utils.machinechecks import (get_installations, get_networkinterfaces,
-                                         get_status_ip, login_test,
-                                         nmap_check, ping_check_ipv4, ping_check_ipv6)
+from orthos2.utils.machinechecks import (
+    get_installations,
+    get_networkinterfaces,
+    get_status_ip,
+    login_test,
+    nmap_check,
+    ping_check_ipv4,
+    ping_check_ipv6,
+)
 from orthos2.utils.misc import sync, wrap80
 from orthos2.utils.ssh import SSH
 

--- a/orthos2/taskmanager/tasks/notifications.py
+++ b/orthos2/taskmanager/tasks/notifications.py
@@ -1,12 +1,12 @@
 import logging
 
 from django.conf import settings
-from django.utils import timezone
 from django.contrib.auth.models import User
+from django.utils import timezone
 
-from orthos2.data.models import Machine, Domain, DomainAdmin
+from orthos2.data.models import Domain, DomainAdmin, Machine
 from orthos2.taskmanager.models import Task
-from orthos2.utils.misc import send_email, get_domain
+from orthos2.utils.misc import get_domain, send_email
 
 logger = logging.getLogger('tasks')
 

--- a/orthos2/taskmanager/tasks/sconsole.py
+++ b/orthos2/taskmanager/tasks/sconsole.py
@@ -1,6 +1,6 @@
 import logging
 
-from orthos2.data.models import ServerConfig, Domain
+from orthos2.data.models import Domain, ServerConfig
 from orthos2.taskmanager.models import Task
 from orthos2.utils.ssh import SSH
 

--- a/orthos2/taskmanager/tasks/setup.py
+++ b/orthos2/taskmanager/tasks/setup.py
@@ -2,8 +2,8 @@ import logging
 
 from orthos2.data.models import Machine, ServerConfig
 from orthos2.taskmanager.models import Task
+from orthos2.utils.cobbler import CobblerException, CobblerServer
 from orthos2.utils.ssh import SSH
-from orthos2.utils.cobbler import CobblerServer, CobblerException
 
 logger = logging.getLogger('tasks')
 

--- a/orthos2/urls.py
+++ b/orthos2/urls.py
@@ -15,8 +15,8 @@ Examples:
         1. Import the include() function: from django.urls import url, include
         2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
-from django.urls import include, re_path
 from django.contrib import admin
+from django.urls import include, re_path
 
 urlpatterns = [
     re_path(r'^', include('orthos2.frontend.urls', namespace='frontend')),

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -172,9 +172,9 @@ class CobblerServer:
         :returns: The corresponding cobbler server or None
         """
         domain = machine.fqdn_domain
-        server = domain.cobbler_server.all()
-        if server and server[0]:
-            return CobblerServer(server[0].fqdn, domain)
+        server = domain.cobbler_server
+        if server:
+            return CobblerServer(server.fqdn, domain)
         return None
 
     def connect(self):

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -3,9 +3,9 @@ import logging
 from django.template import Context, Template
 
 from orthos2.data.models import Machine, ServerConfig
-from orthos2.utils.ssh import SSH
 from orthos2.utils.misc import get_hostname, get_ipv4, get_ipv6
 from orthos2.utils.remotepowertype import RemotePowerType
+from orthos2.utils.ssh import SSH
 
 logger = logging.getLogger('utils')
 

--- a/orthos2/utils/hostnamefinder.py
+++ b/orthos2/utils/hostnamefinder.py
@@ -1,5 +1,5 @@
-import socket
 import logging
+import socket
 
 from django.conf import settings
 

--- a/orthos2/utils/machinechecks.py
+++ b/orthos2/utils/machinechecks.py
@@ -6,8 +6,8 @@ from decimal import Decimal
 
 from orthos2.data.models import Architecture, Installation, Machine, NetworkInterface
 from orthos2.utils.misc import execute, normalize_ascii
-from orthos2.utils.ssh import SSH
 from orthos2.utils.remote import ssh_execute
+from orthos2.utils.ssh import SSH
 
 ARPHRD_IEEE80211 = 801
 

--- a/orthos2/utils/remotepowertype.py
+++ b/orthos2/utils/remotepowertype.py
@@ -1,4 +1,5 @@
 import logging
+
 from django.conf import settings
 
 

--- a/orthos2/utils/ssh.py
+++ b/orthos2/utils/ssh.py
@@ -1,8 +1,8 @@
 import logging
 import os
 import socket
-import paramiko
 
+import paramiko
 from django.conf import settings
 
 from orthos2.data.models import Machine, ServerConfig

--- a/orthos2/utils/tests/test_cobbler.py
+++ b/orthos2/utils/tests/test_cobbler.py
@@ -1,8 +1,8 @@
 import logging
-import mock
-from mock import MagicMock, NonCallableMagicMock
 
+import mock
 from django.test import TestCase
+from mock import MagicMock, NonCallableMagicMock
 
 import orthos2.utils.cobbler as cobbler
 from orthos2.data.models import Architecture, Domain, Machine, MachineGroup

--- a/orthos2/utils/tests/test_misc.py
+++ b/orthos2/utils/tests/test_misc.py
@@ -2,11 +2,18 @@ import logging
 
 import mock
 from django.test import TestCase
+
 from orthos2.utils.machinechecks import nmap_check, ping_check
-from orthos2.utils.misc import (execute, get_domain, get_hostname,
-                                has_valid_domain_ending, is_dns_resolvable,
-                                is_valid_mac_address, normalize_ascii,
-                                str_time_to_datetime)
+from orthos2.utils.misc import (
+    execute,
+    get_domain,
+    get_hostname,
+    has_valid_domain_ending,
+    is_dns_resolvable,
+    is_valid_mac_address,
+    normalize_ascii,
+    str_time_to_datetime,
+)
 
 logging.disable(logging.CRITICAL)
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import os
 from glob import glob
+
 from setuptools import find_packages, setup
 
 logpath = os.environ.get('LOG_PATH', "/var/log/orthos2")


### PR DESCRIPTION
## Description
This action utilizes the `isort --profile=black .` command to format the imports in the entire codebase, resulting in more idiomatic and visually pleasing Python imports.

## Behaviour changes
Before: Unattractive and disorganized imports  
After: Well-formatted and visually appealing imports

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [x] Code Quality
- [x] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 