### PR TITLE
Refactor Domain-CobblerServer relationship to 1:1

### DIFF
--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -117,7 +117,8 @@ class RemotePowerInlineFormset(forms.models.BaseInlineFormSet):
                     port, dev.fence_name))
         else:
             if port:
-                raise forms.ValidationError("Fence {} needs no port, please leave emtpy".format(fence.fence))
+                raise forms.ValidationError(
+                    "Fence {} needs no port, please leave emtpy".format(fence.fence))
 
 
 class RemotePowerInlineRpower(admin.StackedInline):
@@ -281,7 +282,8 @@ class MachineAdminForm(forms.ModelForm):
         hypervisor = cleaned_data.get('hypervisor')
         system = cleaned_data.get('system')
         if hypervisor and System.objects.filter(name=system, virtual=False):
-            self.add_error('system', "System type is not virtual. Only Virtual Machines may have a hypervisor")
+            self.add_error(
+                'system', "System type is not virtual. Only Virtual Machines may have a hypervisor")
             self.add_error('hypervisor', "System type {} is not virtual. Only Virtual Machines may have "
                            "a hypervisor".format(system))
 
@@ -297,8 +299,10 @@ class MachineAdminForm(forms.ModelForm):
             self.add_error('unknown_mac', "MAC unknown must not be selected when a MAC is provided")
             self.add_error('mac_address', "MAC unknown must not be selected when a MAC is provided")
         if not mac and not unknown_mac:
-            self.add_error('unknown_mac', "Either specify a MAC, or confirm that the MAC is not yet known")
-            self.add_error('mac_address', "Either specify a MAC, or confirm that the MAC is not yet known")
+            self.add_error(
+                'unknown_mac', "Either specify a MAC, or confirm that the MAC is not yet known")
+            self.add_error(
+                'mac_address', "Either specify a MAC, or confirm that the MAC is not yet known")
         return cleaned_data
 
 
@@ -591,10 +595,9 @@ class DomainAdmin(admin.ModelAdmin):
     inlines = (ArchsInline, )
 
     def cobbler_server_list(self, obj):
-        """Return DHCP server list as string."""
-        if obj.cobbler_server.all().count() == 0:
-            return '-'
-        return ', '.join([cobbler_server.fqdn for cobbler_server in obj.cobbler_server.all()])
+        """Return DHCP server FQDN as string."""
+        cobbler_server = obj.cobbler_server
+        return cobbler_server.fqdn if cobbler_server else '-'
 
     def delete_model(self, request, obj=None):
         try:

--- a/orthos2/data/management/commands/dump_db.py
+++ b/orthos2/data/management/commands/dump_db.py
@@ -110,8 +110,8 @@ class Command(BaseCommand):
                 self.add_machine(d_obj.tftp_server.fqdn)
             if d_obj.cscreen_server:
                 self.add_machine(d_obj.cscreen_server.fqdn)
-            if d_obj.cobbler_server and len(d_obj.cobbler_server.all()):
-                self.add_machine(d_obj.cobbler_server.all()[0].fqdn)
+            if d_obj.cobbler_server:
+                self.add_machine(d_obj.cobbler_server.fqdn)
 
             query = Domain.objects.filter(name=d_obj)
             self.queries.extend(query)
@@ -135,7 +135,7 @@ class Command(BaseCommand):
         for item in query:
             item.tftp_server = None
             item.cscreen_server = None
-            item.cobbler_server.set([])
+            item.cobbler_server = None
         self.queries.extend(query)
         self.add_machine("markeb.arch.suse.de")
 

--- a/orthos2/data/models/domain.py
+++ b/orthos2/data/models/domain.py
@@ -36,11 +36,13 @@ class Domain(models.Model):
         validators=[validate_domain_ending]
     )
 
-    cobbler_server = models.ManyToManyField(
+    cobbler_server = models.ForeignKey(
         'data.Machine',
         related_name='cobbler_server_for',
         verbose_name='Cobbler server',
+        null=True,
         blank=True,
+        on_delete=models.SET_NULL,
         limit_choices_to={'administrative': True}
     )
 

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -772,7 +772,7 @@ class Machine(models.Model):
     is_administrative.boolean = True
 
     def is_cobbler_server(self):
-        return self.domain_set.all().exists()
+        return self.cobbler_server_for.exists()
     is_cobbler_server.boolean = True
 
     def is_virtual_machine(self):

--- a/orthos2/data/scripts/dump_test_db.py
+++ b/orthos2/data/scripts/dump_test_db.py
@@ -41,7 +41,8 @@ Also see: https://docs.djangoproject.com/en/3.2/topics/serialization
 Modules = {}
 
 # General also includes taskmanager.dailytask and basic arch.suse.de domain
-Modules['general'] = ("Serverconfig", "System", "Architecture", "Vendor", "Platform", "Serialconsoletype")
+Modules['general'] = ("Serverconfig", "System", "Architecture",
+                      "Vendor", "Platform", "Serialconsoletype")
 
 Modules['domain'] = ("Domain", "Domainadmin")
 
@@ -100,8 +101,8 @@ def add_domain(domain: str, queries: list):
             add_machine(d_obj.tftp_server.fqdn, queries)
         if d_obj.cscreen_server:
             add_machine(d_obj.cscreen_server.fqdn, queries)
-        if d_obj.cobbler_server and len(d_obj.cobbler_server.all()):
-            add_machine(d_obj.cobbler_server.all()[0].fqdn, queries)
+        if d_obj.cobbler_server:
+            add_machine(d_obj.cobbler_server.fqdn, queries)
 
         query = Domain.objects.filter(name=d_obj)
         queries.extend(query)

--- a/orthos2/taskmanager/tasks/cobbler.py
+++ b/orthos2/taskmanager/tasks/cobbler.py
@@ -42,7 +42,7 @@ class RegenerateCobbler(Task):
             logger.info("--- Start Cobbler deployment ---")
             for domain in domains:
 
-                if domain.cobbler_server.all().count() == 0:
+                if not domain.cobbler_server:
                     logger.info("Domain '%s' has no Cobbler server... skip", domain.name)
                     continue
 
@@ -53,19 +53,18 @@ class RegenerateCobbler(Task):
                 logger.info("Generate Cobbler configuration for '%s'...", domain.name)
 
                 # deploy generated DHCP files on all servers belonging to one domain
-                for server in domain.cobbler_server.all():
-
-                    cobbler_server = CobblerServer(server.fqdn, domain)
-                    try:
-                        logger.info("* Cobbler deployment started...")
-                        cobbler_server.deploy()
-                        logger.info("* Cobbler deployment finished successfully")
-                    except Exception as e:
-                        message = "* Cobbler deployment failed; {}".format(e)
-                        if isinstance(e, (SystemError, SyntaxError)):
-                            logger.exception(message)
-                        else:
-                            logger.exception(message)
+                cobbler_server = domain.cobbler_server
+                cobbler_server_obj = CobblerServer(cobbler_server.fqdn, domain)
+                try:
+                    logger.info("* Cobbler deployment started...")
+                    cobbler_server_obj.deploy()
+                    logger.info("* Cobbler deployment finished successfully")
+                except Exception as e:
+                    message = "* Cobbler deployment failed; {}".format(e)
+                    if isinstance(e, (SystemError, SyntaxError)):
+                        logger.exception(message)
+                    else:
+                        logger.exception(message)
 
         except SSH.Exception as e:
             logger.exception(e)
@@ -85,23 +84,23 @@ class UpdateCobblerMachine(Task):
             domain = Domain.objects.get(pk=self._domain_id)
             machine = Machine.objects.get(pk=self._machine_id)
             logger.info("Cobbler update started")
-            if domain.cobbler_server.all().count() == 0:
+            if not domain.cobbler_server:
                 logger.info("Domain '%s' has no Cobbler server... aborting", domain.name)
                 return
             logger.info("Generate Cobbler update configuration for '%s'...", machine.fqdn)
             # deploy generated DHCP files on all servers belonging to one domain
-            for server in domain.cobbler_server.all():
-                cobbler_server = CobblerServer(server.fqdn, domain)
-                try:
-                    logger.info("* Cobbler deployment started...")
-                    cobbler_server.update_or_add(machine)
-                    logger.info("* Cobbler deployment finished successfully")
-                except Exception as e:
-                    message = "* Cobbler deployment failed; {}".format(e)
-                    if isinstance(e, (SystemError, SyntaxError)):
-                        logger.exception(message)
-                    else:
-                        logger.exception(message)
+            cobbler_server = domain.cobbler_server
+            cobbler_server_obj = CobblerServer(cobbler_server.fqdn, domain)
+            try:
+                logger.info("* Cobbler deployment started...")
+                cobbler_server_obj.update_or_add(machine)
+                logger.info("* Cobbler deployment finished successfully")
+            except Exception as e:
+                message = "* Cobbler deployment failed; {}".format(e)
+                if isinstance(e, (SystemError, SyntaxError)):
+                    logger.exception(message)
+                else:
+                    logger.exception(message)
         except SSH.Exception as e:
             logger.exception(e)
         except Domain.DoesNotExist:
@@ -126,12 +125,12 @@ class SyncCobblerDHCP(Task):
     def execute(self):
         try:
             domain = Domain.objects.get(pk=self._domain_id)
-            if domain.cobbler_server.all().count() == 0:
+            if not domain.cobbler_server:
                 logger.info("Domain '%s' has no Cobbler server... aborting", domain.name)
                 return
-            for server in domain.cobbler_server.all():
-                cobbler_server = CobblerServer(server.fqdn, domain)
-                cobbler_server.sync_dhcp()
+            cobbler_server = domain.cobbler_server
+            cobbler_server_obj = CobblerServer(cobbler_server.fqdn, domain)
+            cobbler_server_obj.sync_dhcp()
         except Domain.DoesNotExist:
             logger.error("No Domain with id %s, aborting", self._domain_id)
         except Domain.MultipleObjectsReturned:

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -172,9 +172,9 @@ class CobblerServer:
         :returns: The corresponding cobbler server or None
         """
         domain = machine.fqdn_domain
-        server = domain.cobbler_server.all()
-        if server and server[0]:
-            return CobblerServer(server[0].fqdn, domain)
+        server = domain.cobbler_server
+        if server:
+            return CobblerServer(server.fqdn, domain)
         return None
 
     def connect(self):


### PR DESCRIPTION
This pull request addresses the refactoring of the Domain and CobblerServer models relationship from many-to-many to one-to-one. This simplifies the code and removes unnecessary loops when interacting with CobblerServer objects.

Old behavior:

The relationship between Domain and CobblerServer was many-to-many, which allowed multiple CobblerServers to be associated with a single Domain.

New behavior:

The Domain-CobblerServer relationship has been refactored to a one-to-one relationship, meaning that each Domain can now only have one associated CobblerServer.