### PR TITLE
fix: Remove unsupported cobbler_server from django admin panel, run isort

### DIFF
--- a/orthos2/api/commands/__init__.py
+++ b/orthos2/api/commands/__init__.py
@@ -1,20 +1,12 @@
-from orthos2.api.commands.add import (
-    AddAnnotationCommand,
-    AddBMCCommand,
-    AddCommand,
-    AddMachineCommand,
-    AddRemotePowerCommand,
-    AddRemotePowerDeviceCommand,
-    AddSerialConsoleCommand,
-    AddVMCommand,
-)
-from orthos2.api.commands.delete import (
-    DeleteCommand,
-    DeleteMachineCommand,
-    DeleteRemotePowerCommand,
-    DeleteRemotePowerDeviceCommand,
-    DeleteSerialConsoleCommand,
-)
+from orthos2.api.commands.add import (AddAnnotationCommand, AddBMCCommand,
+                                      AddCommand, AddMachineCommand,
+                                      AddRemotePowerCommand,
+                                      AddRemotePowerDeviceCommand,
+                                      AddSerialConsoleCommand, AddVMCommand)
+from orthos2.api.commands.delete import (DeleteCommand, DeleteMachineCommand,
+                                         DeleteRemotePowerCommand,
+                                         DeleteRemotePowerDeviceCommand,
+                                         DeleteSerialConsoleCommand)
 from orthos2.api.commands.info import InfoCommand
 from orthos2.api.commands.power import PowerCommand
 from orthos2.api.commands.query import QueryCommand

--- a/orthos2/api/commands/add.py
+++ b/orthos2/api/commands/add.py
@@ -7,31 +7,14 @@ from django.shortcuts import redirect, reverse
 from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView, get_machine
-from orthos2.api.forms import (
-    AnnotationAPIForm,
-    BMCAPIForm,
-    MachineAPIForm,
-    RemotePowerAPIForm,
-    RemotePowerDeviceAPIForm,
-    SerialConsoleAPIForm,
-    VirtualMachineAPIForm,
-)
-from orthos2.api.serializers.misc import (
-    AuthRequiredSerializer,
-    ErrorMessage,
-    InfoMessage,
-    InputSerializer,
-    Message,
-    Serializer,
-)
-from orthos2.data.models import (
-    BMC,
-    Annotation,
-    Machine,
-    RemotePower,
-    RemotePowerDevice,
-    SerialConsole,
-)
+from orthos2.api.forms import (AnnotationAPIForm, BMCAPIForm, MachineAPIForm,
+                               RemotePowerAPIForm, RemotePowerDeviceAPIForm,
+                               SerialConsoleAPIForm, VirtualMachineAPIForm)
+from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
+                                          InfoMessage, InputSerializer,
+                                          Message, Serializer)
+from orthos2.data.models import (BMC, Annotation, Machine, RemotePower,
+                                 RemotePowerDevice, SerialConsole)
 from orthos2.utils.misc import add_offset_to_date, format_cli_form_errors
 
 logger = logging.getLogger('api')

--- a/orthos2/api/commands/delete.py
+++ b/orthos2/api/commands/delete.py
@@ -7,17 +7,11 @@ from django.shortcuts import redirect, reverse
 from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView
-from orthos2.api.forms import (
-    DeleteMachineAPIForm,
-    DeleteRemotePowerAPIForm,
-    DeleteRemotePowerDeviceAPIForm,
-    DeleteSerialConsoleAPIForm,
-)
-from orthos2.api.serializers.misc import (
-    AuthRequiredSerializer,
-    ErrorMessage,
-    InputSerializer,
-)
+from orthos2.api.forms import (DeleteMachineAPIForm, DeleteRemotePowerAPIForm,
+                               DeleteRemotePowerDeviceAPIForm,
+                               DeleteSerialConsoleAPIForm)
+from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
+                                          InputSerializer)
 from orthos2.data.models import Machine, RemotePowerDevice
 from orthos2.utils.misc import format_cli_form_errors
 

--- a/orthos2/api/commands/power.py
+++ b/orthos2/api/commands/power.py
@@ -3,12 +3,8 @@ from django.http import HttpResponseRedirect
 from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import (
-    AuthRequiredSerializer,
-    ErrorMessage,
-    Message,
-    Serializer,
-)
+from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
+                                          Message, Serializer)
 from orthos2.data.models import RemotePower
 
 

--- a/orthos2/api/commands/regenerate.py
+++ b/orthos2/api/commands/regenerate.py
@@ -3,18 +3,12 @@ from django.http import HttpResponseRedirect
 from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import (
-    AuthRequiredSerializer,
-    ErrorMessage,
-    Message,
-    Serializer,
-)
+from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
+                                          Message, Serializer)
 from orthos2.data.models import Domain, Machine
-from orthos2.data.signals import (
-    signal_cobbler_machine_update,
-    signal_cobbler_regenerate,
-    signal_serialconsole_regenerate,
-)
+from orthos2.data.signals import (signal_cobbler_machine_update,
+                                  signal_cobbler_regenerate,
+                                  signal_serialconsole_regenerate)
 from orthos2.utils.misc import get_domain, get_hostname
 
 

--- a/orthos2/api/commands/release.py
+++ b/orthos2/api/commands/release.py
@@ -3,12 +3,8 @@ from django.http import HttpResponseRedirect
 from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import (
-    AuthRequiredSerializer,
-    ErrorMessage,
-    Message,
-    Serializer,
-)
+from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
+                                          Message, Serializer)
 
 
 class ReleaseCommand(BaseAPIView):

--- a/orthos2/api/commands/rescan.py
+++ b/orthos2/api/commands/rescan.py
@@ -2,7 +2,8 @@ from django.http import HttpResponseRedirect
 from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import ErrorMessage, InfoMessage, Message, Serializer
+from orthos2.api.serializers.misc import (ErrorMessage, InfoMessage, Message,
+                                          Serializer)
 from orthos2.taskmanager.tasks.daily import DailyMachineChecks
 from orthos2.taskmanager.tasks.machinetasks import MachineCheck
 

--- a/orthos2/api/commands/reserve.py
+++ b/orthos2/api/commands/reserve.py
@@ -7,13 +7,8 @@ from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView, get_machine
 from orthos2.api.forms import ReserveMachineAPIForm
-from orthos2.api.serializers.misc import (
-    AuthRequiredSerializer,
-    ErrorMessage,
-    InputSerializer,
-    Message,
-    Serializer,
-)
+from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
+                                          InputSerializer, Message, Serializer)
 from orthos2.data.models import Machine
 from orthos2.utils.misc import add_offset_to_date, format_cli_form_errors
 

--- a/orthos2/api/commands/serverconfig.py
+++ b/orthos2/api/commands/serverconfig.py
@@ -3,11 +3,8 @@ from django.http import JsonResponse
 from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView
-from orthos2.api.serializers.misc import (
-    AuthRequiredSerializer,
-    ErrorMessage,
-    InfoMessage,
-)
+from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
+                                          InfoMessage)
 from orthos2.data.models import ServerConfig
 
 

--- a/orthos2/api/commands/setup.py
+++ b/orthos2/api/commands/setup.py
@@ -5,13 +5,8 @@ from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import re_path
 
 from orthos2.api.commands.base import BaseAPIView, get_machine
-from orthos2.api.serializers.misc import (
-    AuthRequiredSerializer,
-    ErrorMessage,
-    InfoMessage,
-    Message,
-    Serializer,
-)
+from orthos2.api.serializers.misc import (AuthRequiredSerializer, ErrorMessage,
+                                          InfoMessage, Message, Serializer)
 
 logger = logging.getLogger('api')
 

--- a/orthos2/api/forms.py
+++ b/orthos2/api/forms.py
@@ -2,32 +2,17 @@ import logging
 
 from django import forms
 from django.forms import inlineformset_factory
-from django.forms.fields import (
-    BooleanField,
-    CharField,
-    ChoiceField,
-    DateField,
-    DecimalField,
-    IntegerField,
-)
+from django.forms.fields import (BooleanField, CharField, ChoiceField,
+                                 DateField, DecimalField, IntegerField)
 from django.forms.models import ModelChoiceIteratorValue
 from django.template.defaultfilters import slugify
 
-from orthos2.data.models import (
-    Architecture,
-    Enclosure,
-    Machine,
-    MachineGroup,
-    NetworkInterface,
-    RemotePower,
-    RemotePowerDevice,
-    SerialConsole,
-    SerialConsoleType,
-    System,
-    is_unique_mac_address,
-    validate_dns,
-    validate_mac_address,
-)
+from orthos2.data.models import (Architecture, Enclosure, Machine,
+                                 MachineGroup, NetworkInterface, RemotePower,
+                                 RemotePowerDevice, SerialConsole,
+                                 SerialConsoleType, System,
+                                 is_unique_mac_address, validate_dns,
+                                 validate_mac_address)
 from orthos2.data.models.domain import validate_domain_ending
 from orthos2.frontend.forms import ReserveMachineForm, VirtualMachineForm
 

--- a/orthos2/api/models.py
+++ b/orthos2/api/models.py
@@ -6,24 +6,11 @@ from django.db.models import Field, Q
 from django.db.models.functions import Length
 
 from orthos2.api.lookups import NotEqual
-from orthos2.data.models import (
-    Annotation,
-    Architecture,
-    Domain,
-    Enclosure,
-    Installation,
-    Machine,
-    MachineGroup,
-    NetworkInterface,
-    PCIDevice,
-    Platform,
-    RemotePower,
-    SerialConsole,
-    SerialConsoleType,
-    System,
-    User,
-    Vendor,
-)
+from orthos2.data.models import (Annotation, Architecture, Domain, Enclosure,
+                                 Installation, Machine, MachineGroup,
+                                 NetworkInterface, PCIDevice, Platform,
+                                 RemotePower, SerialConsole, SerialConsoleType,
+                                 System, User, Vendor)
 
 logger = logging.getLogger('api')
 

--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -589,7 +589,6 @@ class DomainAdmin(admin.ModelAdmin):
     )
     # enables nifty unobtrusive JavaScript “filter” interface
     filter_horizontal = (
-        'cobbler_server',
         'supported_architectures',
     )
     inlines = (ArchsInline, )

--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -10,28 +10,12 @@ from django.utils.html import format_html
 from orthos2.api.forms import RemotePowerDeviceAPIForm
 from orthos2.utils.remotepowertype import RemotePowerType
 
-from .models import (
-    BMC,
-    Annotation,
-    Architecture,
-    Domain,
-    DomainAdmin,
-    Enclosure,
-    Machine,
-    MachineGroup,
-    MachineGroupMembership,
-    NetworkInterface,
-    Platform,
-    RemotePower,
-    RemotePowerDevice,
-    SerialConsole,
-    SerialConsoleType,
-    ServerConfig,
-    System,
-    Vendor,
-    is_unique_mac_address,
-    validate_mac_address,
-)
+from .models import (BMC, Annotation, Architecture, Domain, DomainAdmin,
+                     Enclosure, Machine, MachineGroup, MachineGroupMembership,
+                     NetworkInterface, Platform, RemotePower,
+                     RemotePowerDevice, SerialConsole, SerialConsoleType,
+                     ServerConfig, System, Vendor, is_unique_mac_address,
+                     validate_mac_address)
 
 
 class BMCInlineFormset(forms.models.BaseInlineFormSet):

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -6,21 +6,15 @@ from copy import deepcopy
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import serializers
-from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
+from django.core.exceptions import (ObjectDoesNotExist, PermissionDenied,
+                                    ValidationError)
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 
 from orthos2.data.exceptions import ReleaseException, ReserveException
-from orthos2.utils.misc import (
-    Serializer,
-    get_domain,
-    get_hostname,
-    get_ipv4,
-    get_ipv6,
-    get_s390_hostname,
-    is_dns_resolvable,
-)
+from orthos2.utils.misc import (Serializer, get_domain, get_hostname, get_ipv4,
+                                get_ipv6, get_s390_hostname, is_dns_resolvable)
 
 from .architecture import Architecture
 from .domain import Domain, DomainAdmin, validate_domain_ending

--- a/orthos2/data/models/remotepower.py
+++ b/orthos2/data/models/remotepower.py
@@ -3,7 +3,8 @@ import logging
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from orthos2.utils.remotepowertype import RemotePowerType, get_remote_power_type_choices
+from orthos2.utils.remotepowertype import (RemotePowerType,
+                                           get_remote_power_type_choices)
 
 from . import ServerConfig
 

--- a/orthos2/data/models/virtualizationapi.py
+++ b/orthos2/data/models/virtualizationapi.py
@@ -82,14 +82,9 @@ class VirtualizationAPI:
         """
         from django.contrib.auth.models import User
 
-        from orthos2.data.models import (
-            Architecture,
-            Machine,
-            RemotePower,
-            SerialConsole,
-            SerialConsoleType,
-            System,
-        )
+        from orthos2.data.models import (Architecture, Machine, RemotePower,
+                                         SerialConsole, SerialConsoleType,
+                                         System)
 
         vm = Machine()
         vm.unsaved_networkinterfaces = []

--- a/orthos2/data/signals.py
+++ b/orthos2/data/signals.py
@@ -3,13 +3,8 @@ import os
 import time
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models.signals import (
-    post_delete,
-    post_init,
-    post_save,
-    pre_delete,
-    pre_save,
-)
+from django.db.models.signals import (post_delete, post_init, post_save,
+                                      pre_delete, pre_save)
 from django.dispatch import Signal, receiver
 
 from orthos2.taskmanager import tasks
@@ -17,13 +12,8 @@ from orthos2.taskmanager.models import TaskManager
 from orthos2.utils.cobbler import CobblerServer
 from orthos2.utils.misc import Serializer, get_hostname
 
-from .models import (
-    Machine,
-    NetworkInterface,
-    SerialConsole,
-    ServerConfig,
-    is_unique_mac_address,
-)
+from .models import (Machine, NetworkInterface, SerialConsole, ServerConfig,
+                     is_unique_mac_address)
 
 logger = logging.getLogger('orthos')
 

--- a/orthos2/frontend/forms.py
+++ b/orthos2/frontend/forms.py
@@ -8,14 +8,8 @@ from django.contrib.auth.models import User
 from django.utils import timezone
 from django.utils.formats import date_format
 
-from orthos2.data.models import (
-    Installation,
-    Machine,
-    Platform,
-    ServerConfig,
-    System,
-    Vendor,
-)
+from orthos2.data.models import (Installation, Machine, Platform, ServerConfig,
+                                 System, Vendor)
 
 logger = logging.getLogger('views')
 

--- a/orthos2/frontend/views.py
+++ b/orthos2/frontend/views.py
@@ -27,28 +27,16 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import ListView
 from rest_framework.authtoken.models import Token
 
-from orthos2.data.models import (
-    Architecture,
-    Domain,
-    Machine,
-    MachineGroup,
-    ReservationHistory,
-    ServerConfig,
-)
+from orthos2.data.models import (Architecture, Domain, Machine, MachineGroup,
+                                 ReservationHistory, ServerConfig)
 from orthos2.taskmanager import tasks
 from orthos2.taskmanager.models import TaskManager
 from orthos2.utils.misc import add_offset_to_date
 
 from .decorators import check_permissions
-from .forms import (
-    NewUserForm,
-    PasswordRestoreForm,
-    PreferencesForm,
-    ReserveMachineForm,
-    SearchForm,
-    SetupMachineForm,
-    VirtualMachineForm,
-)
+from .forms import (NewUserForm, PasswordRestoreForm, PreferencesForm,
+                    ReserveMachineForm, SearchForm, SetupMachineForm,
+                    VirtualMachineForm)
 
 logger = logging.getLogger('views')
 

--- a/orthos2/taskmanager/tasks/__init__.py
+++ b/orthos2/taskmanager/tasks/__init__.py
@@ -1,16 +1,9 @@
 from .cobbler import RegenerateCobbler, SyncCobblerDHCP, UpdateCobblerMachine
-from .daily import (
-    DailyCheckForPrimaryNetwork,
-    DailyCheckReservationExpirations,
-    DailyMachineChecks,
-)
+from .daily import (DailyCheckForPrimaryNetwork,
+                    DailyCheckReservationExpirations, DailyMachineChecks)
 from .machinetasks import MachineCheck, RegenerateMOTD
-from .notifications import (
-    CheckForPrimaryNetwork,
-    CheckMultipleAccounts,
-    CheckReservationExpiration,
-    SendReservationInformation,
-    SendRestoredPassword,
-)
+from .notifications import (CheckForPrimaryNetwork, CheckMultipleAccounts,
+                            CheckReservationExpiration,
+                            SendReservationInformation, SendRestoredPassword)
 from .sconsole import RegenerateSerialConsole
 from .setup import SetupMachine

--- a/orthos2/taskmanager/tasks/machinetasks.py
+++ b/orthos2/taskmanager/tasks/machinetasks.py
@@ -4,15 +4,10 @@ from django.utils import timezone
 
 from orthos2.data.models import Machine, NetworkInterface, ServerConfig
 from orthos2.taskmanager.models import Task
-from orthos2.utils.machinechecks import (
-    get_installations,
-    get_networkinterfaces,
-    get_status_ip,
-    login_test,
-    nmap_check,
-    ping_check_ipv4,
-    ping_check_ipv6,
-)
+from orthos2.utils.machinechecks import (get_installations,
+                                         get_networkinterfaces, get_status_ip,
+                                         login_test, nmap_check,
+                                         ping_check_ipv4, ping_check_ipv6)
 from orthos2.utils.misc import sync, wrap80
 from orthos2.utils.ssh import SSH
 

--- a/orthos2/utils/machinechecks.py
+++ b/orthos2/utils/machinechecks.py
@@ -4,7 +4,8 @@ import socket
 import threading
 from decimal import Decimal
 
-from orthos2.data.models import Architecture, Installation, Machine, NetworkInterface
+from orthos2.data.models import (Architecture, Installation, Machine,
+                                 NetworkInterface)
 from orthos2.utils.misc import execute, normalize_ascii
 from orthos2.utils.remote import ssh_execute
 from orthos2.utils.ssh import SSH

--- a/orthos2/utils/tests/test_misc.py
+++ b/orthos2/utils/tests/test_misc.py
@@ -4,16 +4,10 @@ import mock
 from django.test import TestCase
 
 from orthos2.utils.machinechecks import nmap_check, ping_check
-from orthos2.utils.misc import (
-    execute,
-    get_domain,
-    get_hostname,
-    has_valid_domain_ending,
-    is_dns_resolvable,
-    is_valid_mac_address,
-    normalize_ascii,
-    str_time_to_datetime,
-)
+from orthos2.utils.misc import (execute, get_domain, get_hostname,
+                                has_valid_domain_ending, is_dns_resolvable,
+                                is_valid_mac_address, normalize_ascii,
+                                str_time_to_datetime)
 
 logging.disable(logging.CRITICAL)
 


### PR DESCRIPTION
Since the relationship for cobbler_server changed, it's no longer possible to include it in the filter_horizontal admin panel interface. This fixes the django tooling crashing on runtime.

[   54s] ERRORS: [   54s] <class 'orthos2.data.admin.DomainAdmin'>: (admin.E020) The value of 'filter_horizontal[0]' must be a many-to-many field. [   55s] postinstall script of orthos2-1.2.166+git.1eaf582-sm.1699.1.1.noarch.rpm failed [   55s] ### VM INTERACTION START ### [   55s] [   48.890378][    T1] sysrq: Power Off [   55s] [   48.892758][  T296] reboot: Power down [   55s] ### VM INTERACTION END ###