### PR TITLE
fix: Add remaining arch system mappings to machine form validation

### DIFF
--- a/orthos2/data/templates/admin/data/machine/change_form.html
+++ b/orthos2/data/templates/admin/data/machine/change_form.html
@@ -5,7 +5,13 @@
     document.addEventListener('DOMContentLoaded', function () {
         const architectureSystemMapping = {
             's390x': ['zVM', 'zKVM', 'LPAR zSeries'],
-            'x86_64': ['BareMetal', 'KVM', 'XEN']
+            'x86_64': ['BareMetal', 'KVM', 'XEN', 'HMC'],
+
+            'ppc64': ['LPAR PowerPC', 'PowerVM', 'KVM', 'HMC'],
+            'ppc64le': ['LPAR PowerPC', 'PowerVM', 'KVM', 'HMC'],
+            
+            'aarch64': ['BareMetal', 'KVM'],
+            'embedded': ['BareMetal']
         };
 
         function filterSystems() {


### PR DESCRIPTION
## Description
This pull request adds additional architecture system mappings to the `orthos2` project. The mappings for 'ppc64', 'ppc64le', 'aarch64', and 'embedded' have been updated in `change_form.html`.

## Behaviour changes
**Before:** Limited system mappings for certain architectures  
**After:** Expanded system mappings for 'ppc64', 'ppc64le', 'aarch64', and 'embedded'

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
