### PR TITLE
fix: make platforms be assignable to machines

### DIFF
--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -363,7 +363,6 @@ class Machine(models.Model):
         Platform,
         blank=True,
         null=True,
-        limit_choices_to={'is_cartridge': True},
         on_delete=models.SET_NULL
     )
 


### PR DESCRIPTION
## Description
This pull request addresses an issue where machines could not be assigned to platforms due to a limiting condition in the `Machine` model. The `platform` field in `Machine` was previously filtering platform options to those with the `is_cartridge` flag set to `True`. Given that no platforms had this flag set, no options were available for assignment. This PR removes the `is_cartridge` filter, enabling all platforms to be available for machine assignment.

## Behaviour Changes
**Before:** No platforms could be assigned to machines due to the `is_cartridge` filter.  
**After:** All platforms are now available for assignment to machines.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 