### PR TITLE
Docker: Add development container

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,18 @@
+# Development Container
+
+The workflow is as follows (from the project root folder):
+
+```shell
+podman build -f docker/develop.dockerfile -t orthos2-dev:latest .
+podman run -it -v $PWD:/code --rm -p 8000:8000 localhost/orthos2-dev:latest
+```
+
+If you are inside the container the usage is as follows:
+
+```shell
+pip install -r requirements-devel.txt
+su - orthos
+python3 manage.py test
+```
+
+If you messed something up just hit "Ctrl + D" two times and use the `podman run ...` command to spawn a new container.

--- a/docker/develop.dockerfile
+++ b/docker/develop.dockerfile
@@ -1,0 +1,34 @@
+FROM registry.opensuse.org/opensuse/tumbleweed:latest
+
+# Install system dependencies
+RUN zypper in -y \
+    shadow \
+    python3 \
+    python3-devel \
+    python3-pip \
+    python3-setuptools \
+    gcc \
+    openldap2-devel \
+    cyrus-sasl-devel \
+    jq \
+    sudo
+
+# Create required user
+RUN groupadd -r orthos
+RUN useradd -r -g orthos -d /var/lib/orthos2 -s /bin/bash -c "orthos account" orthos
+
+# Create required directories
+RUN mkdir -p /var/log/orthos2
+RUN mkdir -p /var/lib/orthos2/database
+RUN touch /var/log/orthos2/default.log
+RUN chmod o+w /var/log/orthos2/default.log
+RUN chown -R orthos:orthos /var/log/orthos2
+RUN chown -R orthos:orthos /var/lib/orthos2
+
+# Setup container for work
+WORKDIR /code
+VOLUME /code
+EXPOSE 8000
+
+# Set entrypoint for development
+ENTRYPOINT /bin/bash


### PR DESCRIPTION
This PR adds a development docker container that enables one to execute the Django tests locally without polluting your own machine.

This is a splitout of #212 