### PR TITLE
Tests: Fixup mock path

### DIFF
--- a/orthos2/utils/tests/test_cobbler.py
+++ b/orthos2/utils/tests/test_cobbler.py
@@ -89,9 +89,9 @@ class CobblerMethodTests(TestCase):
         self.assertTrue(" --filename=file.name" in options)
         self.assertTrue(" --ipv6-address=2001:db8::8a2e:370:7334" in options)
 
-    @mock.patch("utils.cobbler.create_cobbler_options",
+    @mock.patch("orthos2.utils.cobbler.create_cobbler_options",
                 mock.MagicMock(return_value="option-string"))
-    @mock.patch("utils.cobbler.get_default_profile", mock.MagicMock(return_value="default_profile"))
+    @mock.patch("orthos2.utils.cobbler.get_default_profile", mock.MagicMock(return_value="default_profile"))
     def test_get_cobbler_add_command(self):
         machine = mock.NonCallableMock()
         path = "/cobbler/path"
@@ -101,9 +101,9 @@ class CobblerMethodTests(TestCase):
         self.assertTrue(" --profile=default_profile" in command)
         self.assertTrue("--netboot-enabled=False")
 
-    @mock.patch("utils.cobbler.create_cobbler_options",
+    @mock.patch("orthos2.utils.cobbler.create_cobbler_options",
                 mock.MagicMock(return_value="option-string"))
-    @mock.patch("utils.cobbler.get_default_profile", mock.MagicMock(return_value="default_profile"))
+    @mock.patch("orthos2.utils.cobbler.get_default_profile", mock.MagicMock(return_value="default_profile"))
     def test_get_cobbler_update_command(self):
         machine = mock.NonCallableMock()
         path = "/cobbler/path"
@@ -167,10 +167,10 @@ class CobblerMethodTests(TestCase):
 
     @mock.patch("orthos2.data.models.Machine.active_machines.filter",
                 MagicMock(return_value=[machine1, machine2]))
-    @mock.patch("utils.cobbler.CobblerServer.get_machines", MagicMock(return_value="test1.foo.bar"))
-    @mock.patch("utils.cobbler.get_cobbler_update_command",
+    @mock.patch("orthos2.utils.cobbler.CobblerServer.get_machines", MagicMock(return_value="test1.foo.bar"))
+    @mock.patch("orthos2.utils.cobbler.get_cobbler_update_command",
                 MagicMock(side_effect=mocked_get_update_command))
-    @mock.patch("utils.cobbler.get_cobbler_add_command",
+    @mock.patch("orthos2.utils.cobbler.get_cobbler_add_command",
                 MagicMock(side_effect=mocked_get_add_command))
     def test_cobbler_deploy(self):
         domain = NonCallableMagicMock(spec_set=Domain)

--- a/orthos2/utils/tests/test_misc.py
+++ b/orthos2/utils/tests/test_misc.py
@@ -36,7 +36,7 @@ class MiscMethodTests(TestCase):
         fqdn = 'foo.bar.foobar.suse.de'
         assert get_hostname(fqdn) == 'foo'
 
-    @mock.patch('utils.misc.socket.gethostbyname')
+    @mock.patch('orthos2.utils.misc.socket.gethostbyname')
     def test_is_dns_resolvable(self, mocked_gethostbyname):
         """is_dns_resolvable() should return True if a FQDN is resolvable, False otherwise."""
         import socket
@@ -84,7 +84,7 @@ class MiscMethodTests(TestCase):
 
 class ChecksMethodTests(TestCase):
 
-    @mock.patch('utils.misc.subprocess.Popen')
+    @mock.patch('orthos2.utils.misc.subprocess.Popen')
     def test_ping_check(self, mocked_popen):
         """ping_check() should return True if a FQDN is pingable, False otherwise."""
         fqdn = 'foo.bar.suse.de'
@@ -94,8 +94,8 @@ class ChecksMethodTests(TestCase):
         mocked_popen.return_value.returncode = 1
         assert ping_check(fqdn) is False
 
-    @mock.patch('utils.machinechecks.socket.socket.connect')
-    @mock.patch('utils.machinechecks.ping_check')
+    @mock.patch('orthos2.utils.machinechecks.socket.socket.connect')
+    @mock.patch('orthos2.utils.machinechecks.ping_check')
     def test_nmap_check(self, mocked_ping_check, mocked_connect):
         """nmap_check() should return True if a host runs SSH, False otherwise."""
         import socket


### PR DESCRIPTION
This PR brings the first improvements to tests from #212.

This will fix up the import paths for the mocks. The error that before looked like this is now not occurring anymore.

```
======================================================================
ERROR: test_is_dns_resolvable (orthos2.utils.tests.test_misc.MiscMethodTests)
is_dns_resolvable() should return True if a FQDN is resolvable, False otherwise.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mock/mock.py", line 1449, in patched
    with self.decoration_helper(patched,
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mock/mock.py", line 1431, in decoration_helper
    arg = exit_stack.enter_context(patching)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/contextlib.py", line 492, in enter_context
    result = _cm_type.__enter__(cm)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mock/mock.py", line 1504, in __enter__
    self.target = self.getter()
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mock/mock.py", line 1691, in <lambda>
    getter = lambda: _importer(target)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/mock/mock.py", line 1330, in _importer
    thing = __import__(import_path)
ModuleNotFoundError: No module named 'utils'
```