### PR TITLE
Admin - Display Add/Change page faster

### DIFF
--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -464,6 +464,7 @@ class MachineAdmin(admin.ModelAdmin):
             ),
         })
     )
+    autocomplete_fields = ["hypervisor"]
 
     def get_queryset(self, request):
         """


### PR DESCRIPTION
The bug was that the Add & Change Machine page wasn't being displayed when a high number of machines (>400) is displayed.

The root cause of the bug is that the list of Hypervisor Hosts is too long. Since Django loads all models with their relations this takes very long when done synchronously. Once we switch the field to asynchronous loading Django can load the list of Hypervisors once the page is already displayed.

Docs: https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.autocomplete_fields

This is a split-out of #209