### PR TITLE
Sconsole: Switch from _cscreen to cscreen user

### DIFF
--- a/orthos2/taskmanager/tasks/sconsole.py
+++ b/orthos2/taskmanager/tasks/sconsole.py
@@ -29,7 +29,7 @@ class RegenerateSerialConsole(Task):
         conn = None
         try:
             conn = SSH(self.fqdn)
-            conn.connect(user='_cscreen')
+            conn.connect(user='cscreen')
 
             _stdout, stderr, exitstatus = conn.execute('touch /dev/shm/.cscreenrc_allow_update')
             if exitstatus != 0:


### PR DESCRIPTION
This is to adjust for the changes in https://github.com/openSUSE/cscreen/pull/8