### PR TITLE
Revert "Sconsole: Switch from _cscreen to cscreen user"

### DIFF
--- a/orthos2/taskmanager/tasks/sconsole.py
+++ b/orthos2/taskmanager/tasks/sconsole.py
@@ -29,7 +29,7 @@ class RegenerateSerialConsole(Task):
         conn = None
         try:
             conn = SSH(self.fqdn)
-            conn.connect(user='cscreen')
+            conn.connect(user='_cscreen')
 
             _stdout, stderr, exitstatus = conn.execute('touch /dev/shm/.cscreenrc_allow_update')
             if exitstatus != 0:


### PR DESCRIPTION
Reverts openSUSE/orthos2#233

The change to cscreen was reverted. As such we need to revert our changes as well.