### PR TITLE
Admin: Fix bug that network switches can't select any architecture

### DIFF
--- a/orthos2/data/static/js/machine_admin.js
+++ b/orthos2/data/static/js/machine_admin.js
@@ -9,7 +9,7 @@ window.addEventListener("load", function () {
                 'ppc64le': ['LPAR PowerPC', 'PowerVM', 'KVM', 'HMC'],
 
                 'aarch64': ['BareMetal', 'KVM'],
-                'embedded': ['BareMetal']
+                'embedded': ['BareMetal', 'Storage Array', 'FC Switch', 'Network Switch', 'Omni-Path Switch']
             };
 
             function filterSystems() {


### PR DESCRIPTION
This PR fixes a very small bug that prevents admins from selecting an architecture in the WebUI for a new machine.