### PR TITLE
Fix: Hostnamefinder script

### DIFF
--- a/orthos2/data/management/commands/find_hostname.py
+++ b/orthos2/data/management/commands/find_hostname.py
@@ -3,7 +3,7 @@
 from django.apps import apps
 from django.core.management.base import BaseCommand
 
-from orthos2.utils.hostnamefind import HostnameFinder
+from orthos2.utils.hostnamefinder import HostnameFinder
 
 
 class Command(BaseCommand):

--- a/orthos2/data/management/commands/find_hostname.py
+++ b/orthos2/data/management/commands/find_hostname.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 from django.apps import apps
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandParser
 
 from orthos2.utils.hostnamefinder import HostnameFinder
 
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         super(Command, self).__init__(*args, **kwargs)
         self.machinesonly = False
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser):
         parser.add_argument('--domain', default="arch.suse.de", help="Domainname")
         parser.add_argument('--arch', default="x86_64", help="architecture")
 

--- a/orthos2/utils/hostnamefinder.py
+++ b/orthos2/utils/hostnamefinder.py
@@ -1,5 +1,6 @@
 import logging
 import socket
+from typing import Dict, List, Optional, Tuple
 
 from django.conf import settings
 
@@ -36,7 +37,7 @@ class HostnameFinder(object):
             return None
         return HostnameFinder(config)
 
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, str]):
         """
         Creates a new object with the given domain model object.
         """
@@ -48,13 +49,13 @@ class HostnameFinder(object):
         else:
             self.ip_range = config['ip_range']
 
-    def free_hostnames(self):
+    def free_hostnames(self) -> Tuple[List[str], List[str]]:
         """
         Returns the free hostnames in the 10.161.<section>.<ip_range> area.
         """
 
-        used = []
-        unused = []
+        used: List[str] = []
+        unused: List[str] = []
         # get the hostnames in the database
         Machines = set(Machine.objects.filter(fqdn_domain__name=self.domain).values_list('fqdn', flat=True))
         for i in self.sections:
@@ -71,7 +72,7 @@ class HostnameFinder(object):
                 unused.append(name)
         return used, unused
 
-    def get_hostname(self):
+    def get_hostname(self) -> Optional[List[str]]:
         hostnames = self.free_hostnames()
         if len(hostnames) < 1:
             return None


### PR DESCRIPTION
Currently, the hostnamefinder command imports a non-existing Python module this problem is present since its introduction in acac6aaa6a089e0b1c2d7bbf793efe41e0102abb.

This was locally fixed in production and was never transferred to the main branch.