### PR TITLE
Fix VirtualMachineAPIForm with missing configuration data

### DIFF
--- a/orthos2/data/models/virtualizationapi.py
+++ b/orthos2/data/models/virtualizationapi.py
@@ -1,8 +1,12 @@
 import logging
 import os
 from datetime import date
+from typing import TYPE_CHECKING
 
 from orthos2.utils.misc import get_random_mac_address
+
+if TYPE_CHECKING:
+    from orthos2.data.models import Machine
 
 logger = logging.getLogger('models')
 
@@ -32,7 +36,7 @@ class VirtualizationAPI:
         (Type.LIBVIRT, 'libvirt'),
     )
 
-    def __init__(self, type, host, *args, **kwargs):
+    def __init__(self, type, host: "Machine", *args, **kwargs):
         """
         Cast plain `VirtualizationAPI` object to respective subclass.
 
@@ -169,7 +173,10 @@ class Libvirt(VirtualizationAPI):
         from orthos2.data.models import ServerConfig
 
         architectures = [self.host.architecture.name]
-        image_directory = ServerConfig.objects.by_key('virtualization.libvirt.images.directory')
+        image_directory = ServerConfig.objects.by_key(
+            'virtualization.libvirt.images.directory',
+            '/var/lib/libvirt/images'
+        )
         image_list = []
 
         try:

--- a/orthos2/frontend/forms.py
+++ b/orthos2/frontend/forms.py
@@ -592,9 +592,12 @@ class VirtualMachineForm(forms.Form):
         self.fields['system'].choices = [
             (system.pk, system.name) for system in System.objects.filter(
                 virtual=True,
-                name="KVM"
+                name__regex=r"\bKVM\b"
             )
         ]
+        if virtualization_api is None:
+            raise ValueError('VirtualMachineForm requires "virtualization_api" (an instance of "VirtualizationAPI") '
+                             'as a kwarg.')
         architectures, image_list = virtualization_api.get_image_list()
         self.fields['architecture'].choices = [(architectures[0], architectures[0])]
         self.fields['image'].choices = [('none', 'None')] + image_list


### PR DESCRIPTION
This fixes the following CI failure:

```
ERROR: test_form (orthos2.api.tests.test_forms.VirtualMachineAPIFormTests)
Test the virtual machine creation API form
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/orthos2/orthos2/orthos2/api/tests/test_forms.py", line 29, in test_form
    form = VirtualMachineAPIForm(
  File "/home/runner/work/orthos2/orthos2/orthos2/frontend/forms.py", line 598, in __init__
    architectures, image_list = virtualization_api.get_image_list()
  File "/home/runner/work/orthos2/orthos2/orthos2/data/models/virtualizationapi.py", line 177, in get_image_list
    directory = '{}/{}/'.format(image_directory.rstrip('/'), architecture)
AttributeError: 'NoneType' object has no attribute 'rstrip'
```