### PR TITLE
Forms: Fixup RemotePowerDeviceAPIForm

### DIFF
--- a/orthos2/api/forms.py
+++ b/orthos2/api/forms.py
@@ -1,6 +1,7 @@
 import logging
 
 from django import forms
+from django.db import models
 from django.forms import inlineformset_factory
 from django.forms.fields import (
     BooleanField,
@@ -556,8 +557,27 @@ class RemotePowerAPIForm(forms.Form, BaseAPIForm):
 
 
 class RemotePowerDeviceAPIForm(forms.ModelForm, BaseAPIForm):
+    class Meta:
+        model = RemotePowerDevice
+        fields = ["fqdn", "mac", "username", "password", "fence_name", "url"]
+
+    remotepower_type_choices = get_remote_power_type_choices("rpower_device")
+
+    fence_name = models.CharField(
+        choices=remotepower_type_choices,
+        max_length=255,
+        verbose_name="Fence Agent",
+    )
+
     password = forms.CharField(label='Password', max_length=256, required=True,
                                widget=forms.PasswordInput(render_value=True))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        remote_power_choices = get_remote_power_type_choices("rpower_device")
+        self.fields["fence_name"].choices = remote_power_choices
+        # Automatic Widget selection doesn't seem to work in this scenario sadly
+        self.fields["fence_name"].widget = forms.Select(choices=remote_power_choices)
 
 
 class DeleteRemotePowerAPIForm(forms.Form, BaseAPIForm):

--- a/orthos2/api/tests/test_forms.py
+++ b/orthos2/api/tests/test_forms.py
@@ -144,10 +144,28 @@ class RemotePowerAPIFormTests(TestCase):
 
 
 class RemotePowerDeviceAPIFormTests(TestCase):
+    remote_power_types = [
+        {
+            'fence': 'apc',
+            'device': 'rpower_device',
+            'username': 'xxx',
+            'password': 'XXX',
+            'port': True,
+            'system': ['Bare Metal']
+        },
+    ]
+
+    @override_settings(REMOTEPOWER_TYPES=remote_power_types)
     def test_form(self):
         """Test the remote power device creation API form"""
         # Arrange & Act
-        form = RemotePowerDeviceAPIForm({"password": "test"})
+        form = RemotePowerDeviceAPIForm({
+            "fqdn": "TODO",
+            "password": "test",
+            "mac": "AA:BB:CC:DD:EE",
+            "username": "TODO",
+            "fence_name": "apc"
+        })
 
         # Assert
         self.assertTrue(form.is_valid())

--- a/orthos2/settings.py
+++ b/orthos2/settings.py
@@ -22,7 +22,6 @@ from django.contrib.messages import constants as messages
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.abspath('/var/lib/orthos2')
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
@@ -84,7 +83,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'orthos2.wsgi.application'
 
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -115,7 +113,6 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
-
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/
@@ -226,19 +223,16 @@ logger = logging.getLogger('orthos')
 
 STATIC_URL = '/static/'
 
-
 # Login URL
 LOGIN_URL = '/login/'
 
 # On logout, go back to the starting page
 LOGOUT_REDIRECT_URL = "/"
 
-
 # Override messages settings for Bootstrap
 MESSAGE_TAGS = {
     messages.ERROR: 'danger'
 }
-
 
 # REST framework
 REST_FRAMEWORK = {
@@ -246,7 +240,6 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     )
 }
-
 
 # Orthos variables
 SERVER_FQDN = 'orthos.domain.tld'
@@ -261,7 +254,34 @@ AUTH_ALLOW_USER_CREATION = False
 # HINT: Configure the DEFAULT_AUTO_FIELD setting ...
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
-REMOTEPOWER_TYPES = []
+# Cobbler has a recommends on `fence_agents` if that is installed these defaults should work out of the box.
+REMOTEPOWER_TYPES = [
+    {
+        'fence': 'redfish',
+        'device': 'bmc',
+        'username': 'root',
+        'identity_file': '/root/.ssh/master',
+        'use_hostname_as_port': True,
+        'arch': ['x86_64', 'aarch64'],
+        'system': ['KVM VM']
+    },
+    {
+        'fence': 'ipmilanplus',
+        'device': 'bmc',
+        'username': 'xxx',
+        'password': 'XXX',
+        'arch': ['x86_64', 'aarch64'],
+        'system': ['Bare Metal']
+    },
+    {
+        'fence': 'apc',
+        'device': 'rpower_device',
+        'username': 'xxx',
+        'password': 'XXX',
+        'port': True,
+        'system': ['Bare Metal']
+    }
+]
 
 # Check for alternative settings file. If this file exists, we use it and evaluate the code.
 # This is intended to be used for production mode.


### PR DESCRIPTION
This fixes the following test error:

```
ERROR: test_form (orthos2.api.tests.test_forms.RemotePowerDeviceAPIFormTests)
Test the remote power device creation API form
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/orthos2/orthos2/orthos2/api/tests/test_forms.py", line 150, in test_form
    form = RemotePowerDeviceAPIForm({"password": "test"})
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/django/forms/models.py", line 350, in __init__
    raise ValueError("ModelForm has no model class specified.")
ValueError: ModelForm has no model class specified.
```