### PR TITLE
Data: Add fence_agent to display columns

### DIFF
--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -646,7 +646,7 @@ admin.site.register(Enclosure, EnclosureAdmin)
 
 class RemotePowerDeviceAdmin(admin.ModelAdmin):
     form = RemotePowerDeviceAPIForm
-    list_display = ['fqdn']
+    list_display = ['fqdn', 'fence_name']
 
 
 admin.site.register(RemotePowerDevice, RemotePowerDeviceAdmin)


### PR DESCRIPTION
This PR adds the fence_agent to the list of remote power devices for the backend.