### PR TITLE
CI: Add master branch automation

### DIFF
--- a/.obs/main.yaml
+++ b/.obs/main.yaml
@@ -1,0 +1,13 @@
+workflow:
+  steps:
+    - trigger_services:
+      project: systemsmanagement:orthos2:master
+      package: orthos2
+    - trigger_services:
+      project: systemsmanagement:orthos2:master
+      package: orthos-client
+  filters:
+    event: push
+    branches:
+      only:
+        - master

--- a/cli/orthos-client.spec
+++ b/cli/orthos-client.spec
@@ -34,10 +34,11 @@ Command line client that provides a shell like command
 line interface based on readline.
 
 %prep
-
-%autosetup
+%autosetup -n orthos2-%{version}
 
 %build
+# Patch the line that is required to make the CLI work in a venv
+sed -i '1 s/^.*$/#!\/usr\/bin\/python3/' cli/orthos2
 
 %install
 mkdir -p %{buildroot}/%{_bindir}


### PR DESCRIPTION
This PR enables the OBS project to automatically build packages for the `master` branch: https://build.opensuse.org/project/show/systemsmanagement:orthos2:master