### PR TITLE
Tasks: Restart cscreend server after config deployment

### DIFF
--- a/config/sudoers.d/cscreen
+++ b/config/sudoers.d/cscreen
@@ -1,0 +1,1 @@
+%_cscreen ALL= NOPASSWD: /usr/bin/systemctl restart cscreend.service

--- a/docs/adminguide/setup.rst
+++ b/docs/adminguide/setup.rst
@@ -59,3 +59,17 @@ Installation/Setup (Production system)
         systemctl start orthos2.socket
         systemctl start orthos2.service
         systemctl start orthos2_taskmanager
+
+Optional: Setup cscreen server
+##############################
+
+The Domain feature of "cscreen" server (`github.com/openSUSE/cscreen <https://github.com/openSUSE/cscreen>`_) requires
+the manual setup of a cscreen server. Follow these steps to ensure that Orthos can regenerate the configuration:
+
+1. Install cscreen (openSUSE ``zypper in cscreen``)
+
+2. Install the cscreen sudoers configuration
+
+3. Setup passwordless SSH keys between the ``orthos`` (Orthos server) to the ``_cscreen`` user (console server).
+
+4. Enable and start the systemd service for cscreen ``systemctl enable --now cscreend.service``

--- a/orthos2/taskmanager/tasks/sconsole.py
+++ b/orthos2/taskmanager/tasks/sconsole.py
@@ -136,8 +136,17 @@ class RegenerateSerialConsole(Task):
                 raise Exception(
                     "Couldn't unlock CScreen ('rm /dev/shm/.cscreenrc_allow_update)"
                 )
-            logger.info("CScreen update for %s finished", self.fqdn)
 
+            # Restart cscreend server
+            _stdout, stderr, exitstatus = conn.execute(
+                "sudo systemctl restart cscreend.service",
+                timeout=30.0,
+            )
+
+            if exitstatus != 0:
+                raise Exception("Couldn't restart cscreen")
+
+            logger.info("CScreen update for %s finished", self.fqdn)
         except SSH.Exception as exception:
             logger.exception(exception)
         except IOError as exception:


### PR DESCRIPTION
Fixes #257 

This adds minimal documentation to deploy the cscreen sever, an example config for sudoers.d and the bugfix in the task so the server is restarted.