### PR TITLE
Fix syntax error in dmidecode

### DIFF
--- a/ansible/roles/add_custom_facts/files/facts.d/dmidecode.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/dmidecode.fact
@@ -8,7 +8,7 @@ data = dict()
 
 command = ["dmidecode"]
 process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-data.update({"noargs":{"stdout":process.stdout.read, "stderr":process.stderr.read}})
+data.update({"noargs":{"stdout":process.stdout.read(), "stderr":process.stderr.read()}})
 
 json_string = json.dumps(data)
 sys.stdout.write(json_string)


### PR DESCRIPTION
This PR fixes an issue where the dmidecode custom fact wasn't correctly reporting its data.