### PR TITLE
Fix: Deploying machines without cscreen server

### DIFF
--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -797,7 +797,10 @@ class Machine(models.Model):
         if update_sconsole:
             from orthos2.data.signals import signal_serialconsole_regenerate
 
-            if hasattr(self.fqdn_domain, "cscreen_server"):
+            if (
+                hasattr(self.fqdn_domain, "cscreen_server")
+                and self.fqdn_domain.cscreen_server is not None
+            ):
                 cscreen_server_fqdn = self.fqdn_domain.cscreen_server.fqdn  # type: ignore
                 signal_serialconsole_regenerate.send(
                     sender=self.__class__, cscreen_server_fqdn=cscreen_server_fqdn

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -663,96 +663,82 @@ class Machine(models.Model):
             # check if DHCP needs to be regenerated
             if self.mac_address != self._original.mac_address:
                 self.delete_secondary_interfaces()
-            try:
-                assert self.mac_address == self._original.mac_address
-                assert self.fqdn == self._original.fqdn
-                assert self.fqdn_domain == self._original.fqdn_domain
-                assert self.architecture == self._original.architecture
-                assert self.group == self._original.group
-                assert self.dhcp_filename == self._original.dhcp_filename
-                assert self.kernel_options == self._original.kernel_options
-                if hasattr(self, "bmc"):
-                    assert hasattr(self._original, "bmc")
-                    assert self.bmc.mac == self._original.bmc.mac
-                    assert self.bmc.fqdn == self._original.bmc.fqdn
-            except AssertionError:
+            if any(
+                [
+                    self.mac_address != self._original.mac_address,
+                    self.fqdn != self._original.fqdn,
+                    self.fqdn_domain != self._original.fqdn_domain,
+                    self.architecture != self._original.architecture,
+                    self.group != self._original.group,
+                    self.dhcp_filename != self._original.dhcp_filename,
+                    self.kernel_options != self._original.kernel_options,
+                ]
+            ):
                 sync_dhcp = True
                 update_machine = True
-            try:
-                if hasattr(self, "bmc"):
-                    assert hasattr(self._original, "bmc")
-                    assert self.bmc.username == self._original.bmc.username
-                    assert self.bmc.password == self._original.bmc.password
-                if self.has_remotepower():
-                    assert hasattr(self._original, "remotepower")
-                    assert (
+            if self.has_bmc():
+                if not hasattr(self._original, "bmc"):
+                    # BMC added
+                    sync_dhcp = True
+                    update_machine = True
+                    update_sconsole = True
+                if hasattr(self._original, "bmc") and any(
+                    [
+                        self.bmc.mac != self._original.bmc.mac,
+                        self.bmc.fqdn != self._original.bmc.fqdn,
+                        self.bmc.username != self._original.bmc.username,
+                        self.bmc.password != self._original.bmc.password,
+                    ]
+                ):
+                    # BMC updated
+                    sync_dhcp = True
+                    update_machine = True
+                    update_sconsole = True
+            if self.has_remotepower():
+                if not hasattr(self._original, "remotepower") or not hasattr(
+                    self._original, "remote_power_device"
+                ):
+                    # Remotepower or remote power device added
+                    update_machine = True
+                if hasattr(self._original, "remotepower") and any(
+                    [
                         self.remotepower.fence_name
-                        == self._original.remotepower.fence_name
-                    )
-                    assert (
-                        self.remotepower.options == self._original.remotepower.options
-                    )
-                    if hasattr(self.remotepower, "remote_power_device"):
-                        assert hasattr(
-                            self._original.remotepower, "remote_power_device"
-                        )
-                        assert (
-                            self.remotepower.remote_power_device
-                            == self._original.remotepower.remote_power_device
-                        )
-                if self.has_serialconsole():
-                    assert hasattr(self._original, "serialconsole")
-                    assert (
+                        != self._original.remotepower.fence_name,
+                        self.remotepower.options != self._original.remotepower.options,
+                    ]
+                ):
+                    # Remotepower updated
+                    update_machine = True
+                if hasattr(self.remotepower, "remote_power_device") and any(
+                    [
+                        not hasattr(self._original.remotepower, "remote_power_device"),
+                        self.remotepower.remote_power_device
+                        != self._original.remotepower.remote_power_device,
+                    ]
+                ):
+                    # Remote power device updated
+                    update_machine = True
+            if self.has_serialconsole():
+                if not hasattr(self._original, "serialconsole"):
+                    # Serial console added
+                    update_sconsole = True
+                    update_machine = True
+                if hasattr(self._original, "serialconsole") and any(
+                    [
                         self.serialconsole.baud_rate
-                        == self._original.serialconsole.baud_rate
-                    )
-                    assert (
+                        != self._original.serialconsole.baud_rate,
                         self.serialconsole.command
-                        == self._original.serialconsole.command
-                    )
-                    assert (
-                        self.serialconsole.stype == self._original.serialconsole.stype
-                    )
-                    assert (
+                        != self._original.serialconsole.command,
+                        self.serialconsole.stype == self._original.serialconsole.stype,
                         self.serialconsole.kernel_device
-                        == self._original.serialconsole.kernel_device
-                    )
-                    assert (
+                        != self._original.serialconsole.kernel_device,
                         self.serialconsole.kernel_device_num
-                        == self._original.serialconsole.kernel_device_num
-                    )
-            except AssertionError:
-                update_machine = True
-            try:
-                if hasattr(self, "bmc"):
-                    assert hasattr(self._original, "bmc")
-                    assert self.bmc.mac == self._original.bmc.mac
-                    assert self.bmc.fqdn == self._original.bmc.fqdn
-                    assert self.bmc.username == self._original.bmc.username
-                    assert self.bmc.password == self._original.bmc.password
-                if self.has_serialconsole():
-                    assert hasattr(self._original, "serialconsole")
-                    assert (
-                        self.serialconsole.baud_rate
-                        == self._original.serialconsole.baud_rate
-                    )
-                    assert (
-                        self.serialconsole.command
-                        == self._original.serialconsole.command
-                    )
-                    assert (
-                        self.serialconsole.stype == self._original.serialconsole.stype
-                    )
-                    assert (
-                        self.serialconsole.kernel_device
-                        == self._original.serialconsole.kernel_device
-                    )
-                    assert (
-                        self.serialconsole.kernel_device_num
-                        == self._original.serialconsole.kernel_device_num
-                    )
-            except AssertionError:
-                update_sconsole = True
+                        != self._original.serialconsole.kernel_device_num,
+                    ]
+                ):
+                    # Serial console updated
+                    update_sconsole = True
+                    update_machine = True
 
             if self.fqdn_domain != self._original.fqdn_domain:
                 logger.info(f"Domain change for: %s", self.fqdn)

--- a/orthos2/data/models/remotepower.py
+++ b/orthos2/data/models/remotepower.py
@@ -163,15 +163,15 @@ class RemotePower(models.Model):
 
     def get_status(self) -> int:
         """Return the current power status."""
-        status = self.Status.UNKNOWN
         result = self._perform("status")
         if not result:
             raise RuntimeError("recieved no result from _perform('status')")
-        result = "\n".join(result)
 
-        if result.lower().find("off") > -1:
+        if result.lower().find("failed to execute power task on") > -1:
+            status = self.Status.UNKNOWN
+        elif result.lower().find("status: off") > -1:
             status = self.Status.OFF
-        elif result.lower().find("on") > -1:
+        elif result.lower().find("status: on") > -1:
             status = self.Status.ON
         else:
             raise RuntimeError("Inconclusive result from _perform('status')")

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -196,7 +196,10 @@ class CobblerServer:
         tftp_server = get_tftp_server(machine)
         kernel_options = machine.kernel_options if machine.kernel_options else ""
 
-        object_id = self._xmlrpc_server.new_system(self._token)
+        if save == CobblerSaveModes.NEW:
+            object_id = self._xmlrpc_server.new_system(self._token)
+        else:
+            object_id = self._xmlrpc_server.get_system_handle(machine.fqdn, self._token)
         if not isinstance(object_id, str):
             raise TypeError("Cobbler System ID must be a string!")
         self._xmlrpc_server.modify_system(object_id, "name", machine.fqdn, self._token)

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -280,6 +280,7 @@ class CobblerServer:
             "ipaddress-bmc": get_ipv4(bmc.fqdn),
             "ipv6address-bmc": get_ipv6(bmc.fqdn),
             "hostname-bmc": get_hostname(bmc.fqdn),
+            "dnsname-bmc": bmc.fqdn,
         }
         self._xmlrpc_server.modify_system(
             object_id, "modify_interface", interface_options, self._token

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -578,6 +578,7 @@ class CobblerServer:
         self.set_netboot_state(machine, True)
         self._xmlrpc_server.save_system(object_id, self._token, "bypass")
 
+    @login_required
     def powerswitch(self, machine: "Machine", action: str) -> str:
         if not self.is_running():
             raise CobblerException(


### PR DESCRIPTION
Currently, when trying to deploy a server to a domain that has no cscreen server set, then a `NoneType` error is thrown. 

Furthermore, to prevent the Python optimizer from removing the `assert` statements in case it is invoked with `-OO`, there was a need to switch to nested `if` statements. The delete case doesn't need to be handled in the `save()` method as it is not invoked for this case.