### PR TITLE
Ansible: Skip dmidecode fact collection on non x86 hardware

### DIFF
--- a/ansible/roles/add_custom_facts/files/facts.d/dmidecode.fact
+++ b/ansible/roles/add_custom_facts/files/facts.d/dmidecode.fact
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
 import json
+import platform
 import subprocess
 import sys
 
 data = dict()
 
-command = ["dmidecode"]
-process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-data.update({"noargs":{"stdout":process.stdout.read(), "stderr":process.stderr.read()}})
+if platform.machine() in ("i386", "i486", "i586", "i686", "x86_64"):
+    command = ["dmidecode"]
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    data.update({"noargs":{"stdout":process.stdout.read(), "stderr":process.stderr.read()}})
 
 json_string = json.dumps(data)
 sys.stdout.write(json_string)


### PR DESCRIPTION
Fixes #303 

This PR skips the execution of the dmidecode custom fact in case we are on non-x86 hardware. An empty dictionary is still returned to allow Orthos to read the empty data.