### PR TITLE
Cobbler: Fix Serial Console, BMC and Power Management deployment code

### DIFF
--- a/orthos2/api/tests/commands/test_info.py
+++ b/orthos2/api/tests/commands/test_info.py
@@ -40,7 +40,7 @@ class InfoTest(APITestCase):
         self.assertTrue("header" in json_response)
         self.assertTrue("type" in json_response["header"])
         self.assertEqual(json_response["header"]["type"], "INFO")
-        self.assertEqual(
+        self.assertIn(
             json_response["data"]["reserved_until"]["value"],
-            "9999-12-31T23:59:59.999999+01:00",
+            ("9999-12-31T22:59:59.999999+01:00", "9999-12-31T23:59:59.999999+01:00"),
         )

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -184,6 +184,9 @@ class CobblerServer:
         :param machine: Machine to be added or updated.
         :param save: Whether to save the machine or not.
         """
+        old_machine_has_bmc = False
+        old_machine_has_remote_power = False
+        old_machine_has_serial_console = False
         default_profile = get_default_profile(machine)
         if not default_profile:
             raise CobblerException(
@@ -200,6 +203,16 @@ class CobblerServer:
             object_id = self._xmlrpc_server.new_system(self._token)
         else:
             object_id = self._xmlrpc_server.get_system_handle(machine.fqdn, self._token)
+            old_machine_dict = self._get_cobbler_datastructure(machine)
+            if "bmc" in old_machine_dict.get("interfaces", {}):
+                old_machine_has_bmc = True
+            if (
+                old_machine_dict.get("serial_device", -1) > -1
+                and old_machine_dict.get("serial_baud_rate", -1) > -1
+            ):
+                old_machine_has_serial_console = True
+            if old_machine_dict.get("power_type", "") != "":
+                old_machine_has_remote_power = True
         if not isinstance(object_id, str):
             raise TypeError("Cobbler System ID must be a string!")
         self._xmlrpc_server.modify_system(object_id, "name", machine.fqdn, self._token)
@@ -218,10 +231,16 @@ class CobblerServer:
                 self._xmlrpc_server.modify_system(
                     object_id, "next_server_v4", ipv4, self._token
                 )
+        if old_machine_has_bmc and not machine.has_bmc():
+            self.remove_bmc(object_id, save)
         if machine.has_bmc():
             self.add_bmc(machine, object_id)
+        if old_machine_has_remote_power and not machine.has_remotepower():
+            self.remove_power_options(object_id, save)
         if machine.has_remotepower():
             self.add_power_options(machine, object_id)
+        if old_machine_has_serial_console and not machine.has_serialconsole():
+            self.remove_serial_console(object_id, save)
         if machine.has_serialconsole():
             self.add_serial_console(machine, object_id)
         self._xmlrpc_server.modify_system(
@@ -471,6 +490,61 @@ class CobblerServer:
                 machine.fqdn,
                 xmlrpc_fault.faultString,
             )
+
+    @login_required
+    def remove_bmc(
+        self, object_id: str, save: CobblerSaveModes = CobblerSaveModes.SKIP
+    ) -> None:
+        """
+        Remove the virtual network interface that is present to represent the out-of-band management.
+
+        :param object_id: ID of object to be added.
+        :param save: Whether to save the machine or not.
+        """
+        self._xmlrpc_server.modify_system(
+            object_id, "delete_interface", "bmc", self._token
+        )
+        if save != CobblerSaveModes.SKIP:
+            self._xmlrpc_server.save_system(object_id, self._token, save.value)
+
+    @login_required
+    def remove_serial_console(
+        self, object_id: str, save: CobblerSaveModes = CobblerSaveModes.SKIP
+    ) -> None:
+        """
+        Remove the options that are representing the serial console kernel options.
+
+        :param object_id: ID of object to be added.
+        :param save: Whether to save the machine or not.
+        """
+        self._xmlrpc_server.modify_system(object_id, "serial_device", -1, self._token)
+        self._xmlrpc_server.modify_system(
+            object_id, "serial_baud_rate", -1, self._token
+        )
+        if save != CobblerSaveModes.SKIP:
+            self._xmlrpc_server.save_system(object_id, self._token, save.value)
+
+    @login_required
+    def remove_power_options(
+        self, object_id: str, save: CobblerSaveModes = CobblerSaveModes.SKIP
+    ) -> None:
+        """
+        Remove the options that are allowing for remote power operations.
+
+        :param object_id: ID of object to be added.
+        :param save: Whether to save the machine or not.
+        """
+        self._xmlrpc_server.modify_system(object_id, "power_type", "", self._token)
+        self._xmlrpc_server.modify_system(object_id, "power_user", "", self._token)
+        self._xmlrpc_server.modify_system(
+            object_id, "power_identity_file", "", self._token
+        )
+        self._xmlrpc_server.modify_system(object_id, "power_pass", "", self._token)
+        self._xmlrpc_server.modify_system(object_id, "power_id", "", self._token)
+        self._xmlrpc_server.modify_system(object_id, "power_address", "", self._token)
+        self._xmlrpc_server.modify_system(object_id, "power_options", "", self._token)
+        if save != CobblerSaveModes.SKIP:
+            self._xmlrpc_server.save_system(object_id, self._token, save.value)
 
     @login_required
     def sync_dhcp(self) -> None:

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -314,34 +314,6 @@ class CobblerServer:
         self._xmlrpc_server.modify_system(
             object_id, "serial_baud_rate", console.baud_rate, self._token
         )
-        if console.kernel_device != "None":
-            system_dict = self._xmlrpc_server.get_system(machine.fqdn)
-            if not isinstance(system_dict, dict):
-                raise TypeError(
-                    'System details for system "%s" must be a dict.' % machine.fqdn
-                )
-            current_kernel_options = system_dict.get("kernel_options", {})
-            if not isinstance(current_kernel_options, (dict, str)):
-                raise TypeError(
-                    'Kernel options for system "%s" must be a dict or str.'
-                    % machine.fqdn
-                )
-            if isinstance(current_kernel_options, str):
-                if current_kernel_options == "<<inherit>>":
-                    new_kernel_options: Dict[str, str] = {}
-                else:
-                    raise TypeError(
-                        'Kernel options for system "%s" were neither inherit nor a dictionary.'
-                        % machine.fqdn
-                    )
-            else:
-                new_kernel_options = current_kernel_options.copy()
-            new_kernel_options[
-                "console"
-            ] = f"{console.kernel_device}{console.kernel_device_num},{console.baud_rate}"
-            self._xmlrpc_server.modify_system(
-                object_id, "kernel_options", new_kernel_options, self._token
-            )
         if save != CobblerSaveModes.SKIP:
             self._xmlrpc_server.save_system(object_id, self._token, save.value)
 

--- a/orthos2/utils/tests/fixtures/machines.json
+++ b/orthos2/utils/tests/fixtures/machines.json
@@ -16,6 +16,15 @@
   }
 },
 {
+  "model": "data.serialconsoletype",
+  "pk": null,
+  "fields": {
+    "name": "IPMI",
+    "command": "ipmitool -I lanplus -H {{ machine.bmc.fqdn }} -U {{ ipmi.user}} -P {{ ipmi.password }} sol activate",
+    "comment": "IPMI"
+  }
+},
+{
   "model": "data.system",
   "pk": null,
   "fields": {
@@ -82,7 +91,7 @@
 },
 {
   "model": "data.machine",
-  "pk": null,
+  "pk": 1,
   "fields": {
     "enclosure": 1,
     "fqdn": "cobbler.orthos2.test",
@@ -136,6 +145,108 @@
     "tftp_server": 1,
     "updated": "2017-11-17T15:36:51.499Z",
     "created": "2017-10-24T14:20:37.298Z"
+  }
+},
+{
+  "model": "data.machine",
+  "pk": 2,
+  "fields": {
+    "enclosure": 1,
+    "fqdn": "testsys.orthos2.test",
+    "system": 1,
+    "comment": "",
+    "serial_number": "",
+    "product_code": "",
+    "architecture": 1,
+    "fqdn_domain": 1,
+    "cpu_model": "",
+    "cpu_flags": "",
+    "cpu_physical": 1,
+    "cpu_cores": 1,
+    "cpu_threads": 1,
+    "cpu_speed": "0.00",
+    "cpu_id": "",
+    "ram_amount": 0,
+    "efi": false,
+    "nda": true,
+    "ipmi": false,
+    "vm_capable": false,
+    "vm_max": 5,
+    "vm_dedicated_host": false,
+    "vm_auto_delete": false,
+    "reserved_until": "9999-12-31T23:59:59.999+00:00",
+    "reserved_reason": "test HOS",
+    "platform": null,
+    "bios_version": "",
+    "bios_date": "2010-10-10",
+    "disk_primary_size": null,
+    "disk_type": "",
+    "lsmod": "",
+    "last": "",
+    "hwinfo": "",
+    "dmidecode": "",
+    "dmesg": "",
+    "lsscsi": "",
+    "lsusb": "",
+    "lspci": "",
+    "status_ipv4": true,
+    "status_ipv6": true,
+    "status_ssh": true,
+    "status_login": false,
+    "administrative": false,
+    "check_connectivity": 3,
+    "collect_system_information": true,
+    "dhcp_filename": null,
+    "active": true,
+    "group": null,
+    "contact_email": "",
+    "tftp_server": 1,
+    "updated": "2017-11-17T15:36:51.499Z",
+    "created": "2017-10-24T14:20:37.298Z"
+  }
+},
+{
+  "model": "data.serialconsole",
+  "pk": 1,
+  "fields": {
+    "stype": 1,
+    "kernel_device": "ttyS",
+    "kernel_device_num": 1,
+    "baud_rate": 115200,
+    "machine": 2
+  }
+},
+{
+  "model": "data.bmc",
+  "pk": 1,
+  "fields": {
+    "username": "root",
+    "password": "root",
+    "fqdn": "testsys-sp.orthos2.test",
+    "mac": "AA:BB:CC:DD:EE:FF",
+    "machine": 2,
+    "fence_name": "ipmilanplus"
+  }
+},
+{
+  "model": "data.networkinterface",
+  "pk": 1,
+  "fields": {
+    "machine": 2,
+    "primary": true,
+    "mac_address": "AA:BB:CC:DD:EE:EF",
+    "name": "unknown",
+    "updated": "2024-08-05T12:25:52.168Z",
+    "created": "2024-08-05T12:25:52.168Z"
+  }
+},
+{
+  "model": "data.remotepower",
+  "pk": null,
+  "fields": {
+    "fence_name": "ipmilanplus",
+    "options": "",
+    "machine": 2
   }
 }
 ]


### PR DESCRIPTION
I found a bug in production during the deployment of some machines:

```
[2025-03-27 12:54:04,241][tasks][DD]: Thread [335018f1] SyncCobblerDHCP:[[13], {}] started...
[2025-03-27 12:54:04,250][tasks][DD]: Thread [f9f3b497] UpdateCobblerMachine exited
[2025-03-27 12:54:06,255][tasks][DD]: Thread [335018f1] SyncCobblerDHCP exited
[2025-03-27 13:31:09,223][tasks][II]: Stop TaskManager...
[2025-03-27 13:31:09,657][tasks][II]: TaskManager stopped; Exit
[2025-03-27 12:31:09,778][orthos][II]: Found alternative settings: /etc/orthos2/settings
[2025-03-27 12:31:09,948][orthos][II]: Found alternative settings: /etc/orthos2/settings
[2025-03-27 13:31:10,430][tasks][II]: TaskManager runs as 'orthos'...
[2025-03-27 13:31:10,430][tasks][II]: Start TaskManager...
[2025-03-27 13:31:41,731][tasks][DD]: Thread [f9f3b497] UpdateCobblerMachine:[[13, 3864], {}] started...
[2025-03-27 13:31:41,746][tasks][II]: Cobbler update started
[2025-03-27 13:31:41,749][tasks][II]: Generate Cobbler update configuration for '<machine>.arch.nue2.suse.org'...
[2025-03-27 13:31:41,749][tasks][II]: * Cobbler deployment started...
[2025-03-27 13:31:41,906][utils][II]: Type system_dict: <class 'str'>
[2025-03-27 13:31:41,906][utils][II]: Content system_dict: ~
[2025-03-27 13:31:41,907][tasks][EE]: * Cobbler deployment failed; System details for system "<machine>.arch.nue2.suse.org" must be a dict.
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/orthos2/taskmanager/tasks/cobbler.py", line 105, in execute
    cobbler_server_obj.update_or_add(machine)
  File "/usr/lib/python3.11/site-packages/orthos2/utils/cobbler.py", line 483, in update_or_add
    self.add_machine(machine, save=CobblerSaveModes.NEW)
  File "/usr/lib/python3.11/site-packages/orthos2/utils/cobbler.py", line 113, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/orthos2/utils/cobbler.py", line 226, in add_machine
    self.add_serial_console(machine, object_id)
  File "/usr/lib/python3.11/site-packages/orthos2/utils/cobbler.py", line 113, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/orthos2/utils/cobbler.py", line 322, in add_serial_console
    raise TypeError(
TypeError: System details for system "<machine>.arch.nue2.suse.org" must be a dict.
[2025-03-27 13:31:41,909][tasks][II]: --- Cobbler deployment finished ---
```

The solution to fix the issue is just to remove the code in Orthos because Cobbler is adding the `console=` kernel option just fine.