### PR TITLE
Verify that new and old Machine have remotepower

### DIFF
--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -706,12 +706,18 @@ class Machine(models.Model):
                 ):
                     # Remotepower updated
                     update_machine = True
-                if hasattr(self.remotepower, "remote_power_device") and any(
-                    [
-                        not hasattr(self._original.remotepower, "remote_power_device"),
-                        self.remotepower.remote_power_device
-                        != self._original.remotepower.remote_power_device,
-                    ]
+                if (
+                    hasattr(self.remotepower, "remote_power_device")
+                    and self._original.has_remotepower()
+                    and any(
+                        [
+                            not hasattr(
+                                self._original.remotepower, "remote_power_device"
+                            ),
+                            self.remotepower.remote_power_device
+                            != self._original.remotepower.remote_power_device,
+                        ]
+                    )
                 ):
                     # Remote power device updated
                     update_machine = True


### PR DESCRIPTION
This fixes an issue that when a new Remote Power Device is set, an `RelatedObjectDoesNoteExist` exception was thrown.