### PR TITLE
Fix: Docker environment variable generation

### DIFF
--- a/docker/manage-secrets.py
+++ b/docker/manage-secrets.py
@@ -78,14 +78,14 @@ netbox_env_file.write_text("\n".join(netbox_env_vars_new) + "\n")
 # ORTHOS2_POSTGRES_PASSWORD
 
 (script_directory / "orthos" / "db.env").write_text(
-    "POSTGRES_USER: orthos\n" f'POSTGRES_PASSWORD="{orthos_db_password}"\n'
+    "POSTGRES_USER=orthos\n" f'POSTGRES_PASSWORD="{orthos_db_password}"\n'
 )
 
 # orthos2.env
 # ORTHOS_SECRET_KEY, ORTHOS_NETBOX_TOKEN
 
 (script_directory / "orthos" / "orthos2.env").write_text(
-    f'ORTHOS_SECRET_KEY="{orthos2_secret_key}"\n'
+    f"ORTHOS_SECRET_KEY='{orthos2_secret_key}'\n"
     'ORTHOS_NETBOX_URL="http://netbox.orthos2.test:8080"\n'
     f"ORTHOS_NETBOX_TOKEN='{netbox_superuser_api_token}'\n"
     f'ORTHOS_SUPERUSER_PASSWORD="{orthos_superuser_password}"\n'

--- a/orthos2/taskmanager/models.py
+++ b/orthos2/taskmanager/models.py
@@ -85,8 +85,8 @@ class Task:
         """
         Execute the task.
 
-        This wrapper is intented to catch unpredictable exceptions in order to log them in the
-        log file (otherwise, exceptions only occure in terminal).
+        This wrapper is intended to catch unpredictable exceptions in order to log them in the
+        log file (otherwise, exceptions only occurs in terminal).
         """
         try:
             self.execute()


### PR DESCRIPTION
This is a split-out of #332

This PR fixes a typo and addresses improperly escaped passwords that caused issues during the startup of the applications in the Docker Compose Stack.