### PR TITLE
Frontend: Add NetBox-powered AddMachine view

### DIFF
--- a/orthos2/frontend/forms/addmachine.py
+++ b/orthos2/frontend/forms/addmachine.py
@@ -1,0 +1,155 @@
+from typing import Any, Dict
+
+from django import forms
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import IntegrityError
+from django.forms import BaseForm
+from django.http import HttpResponse
+from django.urls import reverse
+from django.views.generic.edit import FormView
+from requests import HTTPError
+
+from orthos2.data.models import Architecture, Enclosure, Machine, System
+from orthos2.utils.netbox import Netbox
+
+
+def safe_fetch_device(netbox_api: Netbox, netbox_id: str) -> Dict[str, Any]:
+    try:
+        result = netbox_api.fetch_device(int(netbox_id))
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            return {}
+        raise e
+    return result
+
+
+def safe_fetch_vm(netbox_api: Netbox, netbox_id: str) -> Dict[str, Any]:
+    try:
+        result = netbox_api.fetch_vm(int(netbox_id))
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            return {}
+        raise e
+    return result
+
+
+class AddMachineForm(forms.Form):
+    netbox_id = forms.CharField(
+        required=True,
+        label="NetBox ID",
+        help_text="The ID that NetBox gives to the object.",
+    )
+    system = forms.ModelChoiceField(
+        queryset=System.objects.all(),
+        required=True,
+        help_text="The system type the NetBox machine belongs to. In case the given NetBox ID is for an enclosure, "
+        "this field is ignored.",
+    )
+    netbox_object_type = forms.ChoiceField(
+        choices=[
+            ("device", "Device"),
+            ("vm", "Virtual Machine"),
+        ],
+        required=True,
+        label="NetBox Object Type",
+        help_text="The type of the NetBox object to be added. This is used to determine if the NetBox ID refers to a "
+        "Device or a Virtual Machine.",
+    )
+
+    def clean(self) -> None:
+        """
+        Verify that a single Device or VM in NetBox exists with the given ID.
+        """
+        if not self.is_valid():
+            return
+        netbox_api = Netbox.get_instance()
+        if self.cleaned_data["netbox_object_type"] == "device":
+            netbox_obj = safe_fetch_device(netbox_api, self.cleaned_data["netbox_id"])
+            if not netbox_obj:
+                self.add_error("netbox_id", "No NetBox Device found with the given ID.")
+                return
+        elif self.cleaned_data["netbox_object_type"] == "vm":
+            netbox_obj = safe_fetch_vm(netbox_api, self.cleaned_data["netbox_id"])
+            if not netbox_obj:
+                self.add_error(
+                    "netbox_id", "No NetBox Virtual Machine found with the given ID."
+                )
+                return
+
+
+class AddMachineFormView(FormView):
+    template_name = "frontend/machines/add.html"
+    form_class = AddMachineForm
+
+    def __init__(self, **kwargs):
+        super(AddMachineFormView, self).__init__(**kwargs)
+        self.__machine_pk = 0
+
+    def get_context_data(self, **kwargs):
+        context = super(AddMachineFormView, self).get_context_data(**kwargs)
+        context["title"] = "Add Machine"
+        return context
+
+    def form_valid(self, form: BaseForm) -> HttpResponse:
+        netbox_api = Netbox.get_instance()
+        netbox_object_type = form.data["netbox_object_type"]
+        if netbox_object_type == "device":
+            netbox_object = safe_fetch_device(netbox_api, form.data["netbox_id"])
+            object_name = netbox_object.get("name", "")
+            # Try existing enclosure
+            try:
+                existing_enclosure = Enclosure.objects.get(name=object_name)
+                existing_enclosure.netbox_id = form.data["netbox_id"]
+                existing_enclosure.save()
+                return super().form_valid(form)
+            except ObjectDoesNotExist:
+                # Try next objects type
+                pass
+        else:
+            netbox_object = safe_fetch_vm(netbox_api, form.data["netbox_id"])
+            object_name = netbox_object.get("name", "")
+        # Try existing machine
+        try:
+            existing_machine = Machine.objects.get(fqdn=object_name)
+            existing_machine.netbox_id = form.data["netbox_id"]
+            existing_machine.save()
+            self.__machine_pk = existing_machine.pk
+            return super().form_valid(form)
+        except ObjectDoesNotExist:
+            # Try next object type
+            pass
+        # Create new machine
+        machine_arch = netbox_object.get("custom_fields", {}).get("arch")
+        if machine_arch is None:
+            form.add_error(
+                "netbox_id",
+                "Machine or VM doesn't have a CPU Architecture set in NetBox.",
+            )
+            return super().form_invalid(form)
+        try:
+            target_arch = Architecture.objects.get(name=machine_arch)
+        except ObjectDoesNotExist:
+            form.add_error(
+                "netbox_id",
+                "Machine architecture couldn't be found in Orthos 2 or not set in NetBox.",
+            )
+            return super().form_invalid(form)
+        new_machine = Machine()
+        new_machine.fqdn = object_name
+        new_machine.architecture = target_arch
+        new_machine.system_id = form.data["system"]
+        new_machine.netbox_id = form.data["netbox_id"]
+        try:
+            new_machine.save()
+        except ValidationError as e:
+            form.add_error("netbox_id", e)
+            return super().form_invalid(form)
+        except IntegrityError as e:
+            form.add_error("netbox_id", str(e))
+            return super().form_invalid(form)
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        if self.__machine_pk > 0:
+            return reverse("frontend:detail", args=[self.__machine_pk])
+        return reverse("frontend:machines")

--- a/orthos2/frontend/templates/frontend/machines/add.html
+++ b/orthos2/frontend/templates/frontend/machines/add.html
@@ -1,0 +1,49 @@
+{% extends 'frontend/base.html' %}
+{% load static %}
+{% load tags %}
+{% load filters %}
+
+{% block navbar %}
+{% include 'frontend/snippet.navlinks.html' %}
+{% endblock %}
+
+{% block content %}
+    <form class="form-machine-add" action="{% url 'frontend:machine_add' %}" method="post">
+        {% csrf_token %}
+
+        {{ form.netbox_id.errors }}
+        <div class="row" style="margin: 5px;">
+          <div class="col-3">
+            <label for="{{ form.netbox_id.id_for_label }}">{{ form.netbox_id.label }}:</label>
+          </div>
+          <div class="col-9">
+            {{ form.netbox_id }}
+            <small class="form-text text-muted">{{ form.netbox_id.help_text }}</small>
+          </div>
+        </div>
+
+        {{ form.system.errors }}
+        <div class="row" style="margin: 5px;">
+          <div class="col-3">
+            <label for="{{ form.system.id_for_label }}">{{ form.system.label }}:</label>
+          </div>
+          <div class="col-9">
+            {{ form.system }}
+            <small class="form-text text-muted">{{ form.system.help_text }}</small>
+          </div>
+        </div>
+
+        {{ form.netbox_object_type.errors }}
+        <div class="row" style="margin: 5px;">
+          <div class="col-3">
+            <label for="{{ form.netbox_object_type.id_for_label }}">{{ form.netbox_object_type.label }}:</label>
+          </div>
+          <div class="col-9">
+            {{ form.netbox_object_type }}
+            <small class="form-text text-muted">{{ form.netbox_object_type.help_text }}</small>
+          </div>
+        </div>
+
+        <button type="submit" class="btn btn-secondary btn-sm btn-block">Submit</button>
+    </form>
+{% endblock %}

--- a/orthos2/frontend/templates/frontend/snippet.navlinks.html
+++ b/orthos2/frontend/templates/frontend/snippet.navlinks.html
@@ -18,4 +18,9 @@
   <li class="nav-item {% active_view request 'statistics' %}">
     <a class="nav-link" href="{% url 'frontend:statistics' %}">Statistics</a>
   </li>
+  {% if perms.data and perms.data.add_machine  %}
+  <li class="nav-item {% active_view request 'machine_add' %}">
+    <a class="nav-link" href="{% url 'frontend:machine_add' %}">Add Machine</a>
+  </li>
+  {% endif %}
 </ul>

--- a/orthos2/frontend/urls.py
+++ b/orthos2/frontend/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
         name="virtual_machines",
     ),
     re_path(r"^machines/search", views.machine_search, name="advanced_search"),
+    path("machine/add", views.machine_add, name="machine_add"),
     re_path(r"^machine/(?P<id>[0-9]+)/$", views.machine, name="detail"),
     re_path(r"^machine/(?P<id>[0-9]+)/detail$", views.machine, name="detail"),
     re_path(r"^machine/(?P<id>[0-9]+)/cpu$", views.cpu, name="cpu"),


### PR DESCRIPTION
Follow-Up and Split-Out of #332 

This PR adds a frontend page that allows users with the corresponding permissions to add machines that are present in NetBox.