### PR TITLE
Virtualization: Get rid of reverse inheritance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Start Compose Stack
         run: |
           docker compose -f compose.yaml -f compose.override.yml up -d
-      - name: Wait for Cobbler to run
-        run: |
-          sleep 60
       - name: Run Tests
         run: |
           docker compose exec -it orthos2 bash -c 'coverage run --source="." manage.py test orthos2'
@@ -69,9 +66,7 @@ jobs:
         run: |
           docker compose -f compose.yaml -f compose.override.yml up -d
       - name: Generate Django Token
-        # Wait 10 seconds so the container can start
         run: |
-          sleep 10
           docker compose cp orthos2:/var/lib/orthos2/admin-token .
           echo "ORTHOS_DJANGO_ADMIN_TOKEN=$(cat ./admin-token)" >> $GITHUB_ENV
       - name: Configure orthosrc

--- a/orthos2/data/models/__init__.py
+++ b/orthos2/data/models/__init__.py
@@ -26,7 +26,6 @@ from .serialconsoletype import SerialConsoleType
 from .serverconfig import ServerConfig, ServerConfigManager, ServerConfigSSHManager
 from .system import System
 from .vendor import Vendor
-from .virtualizationapi import Libvirt, VirtualizationAPI
 
 __all__ = [
     "Annotation",
@@ -60,6 +59,4 @@ __all__ = [
     "ServerConfigSSHManager",
     "System",
     "Vendor",
-    "VirtualizationAPI",
-    "Libvirt",
 ]

--- a/orthos2/data/models/networkinterface.py
+++ b/orthos2/data/models/networkinterface.py
@@ -85,6 +85,12 @@ class NetworkInterface(models.Model):
         auto_now_add=True,
     )
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # The two attributes below are only used for network interfaces that are attached to a VM.
+        self.model = ""
+        self.bridge = ""
+
     def natural_key(self) -> Tuple[str]:
         return (self.mac_address,)
 

--- a/orthos2/data/tests/virtualisation/test_factory.py
+++ b/orthos2/data/tests/virtualisation/test_factory.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from orthos2.data.virtualization import VirtualizationAPI
+from orthos2.data.virtualization.factory import virtualization_api_factory
+from orthos2.data.virtualization.libvirt import Libvirt
+
+
+class VirtualizationFactoryTest(TestCase):
+    def test_factory_none(self):
+        """
+        Test to verify that the factory returns None in case an unkown provider is requested.
+        """
+        self.assertIsNone(virtualization_api_factory(999, None))  # type: ignore
+
+    def test_factory_libvirt(self):
+        """
+        Test to verify that the factory can produce a libvirt implementation of the virtualization API.
+        """
+        self.assertTrue(
+            isinstance(
+                virtualization_api_factory(VirtualizationAPI.Type.LIBVIRT, None),  # type: ignore
+                Libvirt,
+            )
+        )

--- a/orthos2/data/tests/virtualisation/test_virtualisationapi.py
+++ b/orthos2/data/tests/virtualisation/test_virtualisationapi.py
@@ -1,0 +1,134 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from orthos2.data.models.architecture import Architecture
+from orthos2.data.models.domain import Domain
+from orthos2.data.models.machine import Machine
+from orthos2.data.models.remotepowertype import RemotePowerType
+from orthos2.data.models.serverconfig import ServerConfig
+from orthos2.data.models.system import System
+from orthos2.data.virtualization import VirtualizationAPI
+
+
+class VirtualizationAPITest(TestCase):
+    def test_type_to_str(self):
+        """
+        Test that converting the type to str works as expected.
+        """
+        self.assertEqual(VirtualizationAPI.Type.to_str(0), "libvirt")
+
+    def test_type_to_str_error(self):
+        """
+        Test that converting an invalid type to str raises an exception.
+        """
+        self.assertRaises(Exception, VirtualizationAPI.Type.to_str, 999)
+
+    def test_type_to_int(self):
+        """
+        Test that converting the type to int works as expected.
+        """
+        self.assertEqual(VirtualizationAPI.Type.to_int("libvirt"), 0)
+
+    def test_type_to_int_error(self):
+        """
+        Test that converting an invalid type to int raises an exception.
+        """
+        self.assertRaises(Exception, VirtualizationAPI.Type.to_int, "garbage")
+
+    def test_get_image_list(self):
+        """
+        Test to verify that the base method raises the NotImplementedError.
+        """
+        # Arrange
+        virt_api = VirtualizationAPI(1, None)  # type: ignore
+
+        # Act & Assert
+        self.assertRaises(NotImplementedError, virt_api.get_image_list)
+
+    def test_create(self):
+        """
+        TODO
+        """
+
+        # Arrange
+        def fake_create(vm: "Machine", *args: Any, **kwargs: Any):
+            vm.fqdn = "mytest.orthos2.test"
+            vm.hypervisor = fake_hypervisor
+            vm.vnc = {"enabled": False, "port": 5901}
+            return True
+
+        system_kvm = System.objects.get(name="VM KVM")
+        RemotePowerType.objects.create(name="virsh", device="hypervisor")
+        ServerConfig.objects.create(key="domain.validendings", value="orthos2.test")
+        Domain.objects.create(
+            name="orthos2.test",
+            ip_v4="127.0.0.1",
+            ip_v6="::1",
+            dynamic_range_v4_start="127.0.0.1",
+            dynamic_range_v4_end="127.0.0.1",
+            dynamic_range_v6_start="::1",
+            dynamic_range_v6_end="::1",
+        )
+        fake_hypervisor = Machine.objects.create(
+            fqdn="hypervisor.orthos2.test",
+            vm_dedicated_host=True,
+            virt_api_int=0,
+            system=System.objects.get(name="BareMetal"),
+            architecture=Architecture.objects.get(name="x86_64"),
+        )
+        virt_api = VirtualizationAPI(0, fake_hypervisor)
+        virt_api._create = fake_create  # type: ignore
+
+        # Act
+        virt_api.create(architecture="x86_64", system=system_kvm.pk)
+
+        # Assert
+        self.assertTrue(True)
+
+    def test_remove(self):
+        """
+        TODO
+        """
+        # Arrange
+        virt_api = VirtualizationAPI(1, None)  # type: ignore
+        virt_api._remove = MagicMock(return_value=True)  # type: ignore
+
+        # Act
+        result = virt_api.remove()
+
+        # Assert
+        self.assertTrue(result)
+
+    def test_get_list(self):
+        """
+        Test to verify that the base method raises the NotImplementedError.
+        """
+        # Arrange
+        virt_api = VirtualizationAPI(1, None)  # type: ignore
+
+        # Act & Assert
+        self.assertRaises(NotImplementedError, virt_api.get_list)
+
+    def test_str(self):
+        """
+        Test to verify that the string representation of the object is stable.
+        """
+        # Arrange
+        virt_api = VirtualizationAPI(0, None)  # type: ignore
+
+        # Act & Assert
+        self.assertEqual(str(virt_api), "libvirt")
+
+    def test_repr(self):
+        """
+        Test to verify that the __repr__ of the object is working as desired.
+        """
+        # Arrange
+        virt_api = VirtualizationAPI(0, None)  # type: ignore
+        virt_api.host = MagicMock()
+        virt_api.host.fqdn = "my.test.host"
+
+        # Act & Assert
+        self.assertEqual(repr(virt_api), "<VirtualizationAPI: libvirt (my.test.host)>")

--- a/orthos2/data/virtualization/__init__.py
+++ b/orthos2/data/virtualization/__init__.py
@@ -1,0 +1,139 @@
+"""
+Module to define the common and abstract components to implement a concrete virtualization provider.
+"""
+
+import logging
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any, List, Tuple
+
+from orthos2.data.models.remotepowertype import RemotePowerType
+
+if TYPE_CHECKING:
+    from orthos2.data.models.machine import Machine
+
+logger = logging.getLogger("models")
+
+
+class VirtualizationAPI:
+    """
+    Abstract base class that virtualization API providers have to implement.
+    """
+
+    class Type:
+        """
+        Embedded class to have a Django compatible way of offering the available virtualization APIs.
+        """
+
+        LIBVIRT = 0
+
+        @classmethod
+        def to_str(cls, index: int) -> str:
+            """Return type as string (Virtualization API type name) by index."""
+            for type_tuple in VirtualizationAPI.TYPE_CHOICES:
+                if int(index) == type_tuple[0]:
+                    return type_tuple[1]
+            raise Exception(
+                "Virtualization API type with ID '{}' doesn't exist!".format(index)
+            )
+
+        @classmethod
+        def to_int(cls, name: str) -> int:
+            """Return type as integer if name matches."""
+            for type_tuple in VirtualizationAPI.TYPE_CHOICES:
+                if name.lower() == type_tuple[1].lower():
+                    return type_tuple[0]
+            raise Exception("Virtualization API type '{}' not found!".format(name))
+
+    TYPE_CHOICES = ((Type.LIBVIRT, "libvirt"),)
+
+    def __init__(self, type: int, host: "Machine") -> None:
+        """
+        Constructor for the parent class of virtualization APIs.
+        """
+        self.type = type
+        self.host = host
+
+    def get_image_list(self) -> Tuple[List[str], List[Tuple[str, str]]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _create(self, vm: "Machine", *args: Any, **kwargs: Any) -> bool:
+        """
+        Wrapper function for creating a VM. This should implement the provider specific real creation of a VM.
+        """
+
+    def create(self, *args: Any, **kwargs: Any) -> "Machine":
+        """
+        Create a virtual machine.
+
+        Method returns a new `Machine` object and calls the subclass to actually create the virtual
+        machine physically.
+        """
+        from django.contrib.auth.models import User
+
+        from orthos2.data.models import (
+            Architecture,
+            Machine,
+            RemotePower,
+            SerialConsole,
+            SerialConsoleType,
+            System,
+        )
+
+        vm = Machine()
+        vm.unsaved_networkinterfaces = []
+
+        vm.architecture = Architecture.objects.get(name=kwargs["architecture"])
+        vm.system = System.objects.get(pk=kwargs["system"])
+
+        self._create(vm, *args, **kwargs)
+
+        vm.check_connectivity = Machine.Connectivity.ALL
+        vm.collect_system_information = True
+        vm.save()
+
+        for networkinterface in vm.unsaved_networkinterfaces[1:]:
+            networkinterface.machine = vm
+            networkinterface.save()
+        try:
+            fence_agent = RemotePowerType.objects.get(name="virsh")
+            vm.remotepower = RemotePower(fence_agent=fence_agent)
+        except RemotePowerType.DoesNotExist:
+            logger.warning(
+                "RemotePowerType 'virsh' not found. Please add remotepower for VM %s manually!",
+                vm.hostname,
+            )
+        vm.remotepower.save()
+
+        if self.host.has_serialconsole():
+            stype = SerialConsoleType.objects.get(name="libvirt/qemu")
+            if not stype:
+                raise Exception("Bug: SerialConsoleType not found")
+            vm.serialconsole = SerialConsole(stype=stype, baud_rate=115200)
+            vm.serialconsole.save()
+
+        if vm.vnc["enabled"]:
+            vm.annotations.create(
+                text=f"VNC enabled: {self.host.fqdn}:{vm.vnc['port']}",
+                reporter=User.objects.get(username="admin"),
+            )
+
+        return vm
+
+    @abstractmethod
+    def _remove(self, *args: Any, **kwargs: Any) -> bool:
+        """
+        Wrapper function for removing a VM. This should implement the provider specific real creation of a VM.
+        """
+
+    def remove(self, *args: Any, **kwargs: Any) -> bool:
+        return self._remove(*args, **kwargs)
+
+    def get_list(self) -> str:
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        return self.Type.to_str(self.type)
+
+    def __repr__(self) -> str:
+        return "<VirtualizationAPI: {} ({})>".format(self, self.host.fqdn)

--- a/orthos2/data/virtualization/factory.py
+++ b/orthos2/data/virtualization/factory.py
@@ -1,0 +1,22 @@
+"""
+Module to provide a method to create a concrete virtualization object.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+from orthos2.data.virtualization import VirtualizationAPI
+from orthos2.data.virtualization.libvirt import Libvirt
+
+if TYPE_CHECKING:
+    from orthos2.data.models.machine import Machine
+
+
+def virtualization_api_factory(
+    virt_api: Optional[int], machine: "Machine"
+) -> Optional[VirtualizationAPI]:
+    """
+    Factory to create a concrete instance of one of the available virtualization API providers.
+    """
+    if virt_api == VirtualizationAPI.Type.LIBVIRT:
+        return Libvirt(machine)
+    return None


### PR DESCRIPTION
This PR fixes an issue with the Virtualisation API that caused the type checkers to not be able to verify the typing of the object.