### PR TITLE
Pull network interfaces from NetBox

### DIFF
--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -844,11 +844,7 @@ class Machine(models.Model):
             raise ValidationError(
                 "{} systems cannot use a BMC".format(self.system.name)
             )
-        # create & assign network domain and ensure that the FQDN always matches the fqdn_domain
-        domain, created = Domain.objects.get_or_create(name=get_domain(self.fqdn))
-        if created:
-            domain.save()
-        self.fqdn_domain = domain
+        self.fqdn_domain = Domain.objects.get(name=get_domain(self.fqdn))
 
         # create & assign enclosure according to naming convention if no enclosure given
         if not hasattr(self, "enclosure"):

--- a/orthos2/taskmanager/tasks/__init__.py
+++ b/orthos2/taskmanager/tasks/__init__.py
@@ -5,7 +5,13 @@ from .daily import (
     DailyMachineChecks,
 )
 from .machinetasks import MachineCheck, RegenerateMOTD
-from .netbox import NetboxFetchEnclosure, NetboxFetchFullMachine, NetboxFetchMachine
+from .netbox import (
+    NetboxFetchBMC,
+    NetboxFetchEnclosure,
+    NetboxFetchFullMachine,
+    NetboxFetchMachine,
+    NetboxFetchNetworkInterface,
+)
 from .notifications import (
     CheckForPrimaryNetwork,
     CheckMultipleAccounts,
@@ -25,9 +31,11 @@ __all__ = [
     "DailyMachineChecks",
     "MachineCheck",
     "RegenerateMOTD",
+    "NetboxFetchBMC",
     "NetboxFetchEnclosure",
     "NetboxFetchFullMachine",
     "NetboxFetchMachine",
+    "NetboxFetchNetworkInterface",
     "CheckForPrimaryNetwork",
     "CheckMultipleAccounts",
     "CheckReservationExpiration",

--- a/orthos2/taskmanager/tasks/daily.py
+++ b/orthos2/taskmanager/tasks/daily.py
@@ -85,3 +85,5 @@ class DailyNetboxFetch(Task):
 
         TaskManager.add(tasks.NetboxFetchEnclosure())
         TaskManager.add(tasks.NetboxFetchMachine())
+        TaskManager.add(tasks.NetboxFetchNetworkInterface())
+        TaskManager.add(tasks.NetboxFetchBMC())


### PR DESCRIPTION
To shift more towards a NetBox-centric approach, this PR removes the collection of network interfaces via Ansible and pulls them only from NetBox.

The planned replacement to allow easier adding of network interfaces from a given machine into NetBox is https://github.com/The-Nazara-Project/Nazara/