### PR TITLE
Feature: Add NetboxOrthosComparisonRun UI

### DIFF
--- a/orthos2/frontend/templates/frontend/netboxorthoscomparison/details.html
+++ b/orthos2/frontend/templates/frontend/netboxorthoscomparison/details.html
@@ -1,0 +1,65 @@
+{% extends 'frontend/base.html' %}
+
+{% load static %}
+{% load tags %}
+{% load filters %}
+
+{% block navbar %}
+
+{% include 'frontend/snippet.navlinks.html' %}
+
+{% endblock %}
+
+{% block content %}
+
+<div class="container-fluid">
+  <div class="title">
+    <h3 class="gray">{{ run.run_id }}</h3>
+  </div>
+
+  <table class="table table-striped table-bordered small">
+    <tbody class="thead-default">
+      <tr>
+        <td class="th" width="150px">Comparison run at:</td>
+        <td>{{ run.compare_timestamp }}</td>
+      </tr>
+      <tr>
+        <td class="th" width="150px">Object type:</td>
+        <td>{{ run.object_type }}</td>
+      </tr>
+      <tr>
+        <td class="th" width="150px">Object Name:</td>
+        {% if run.object_type == "bmc" %}
+        <td>{{ run.object_bmc.fqdn }}</td>
+        {% elif run.object_type == "enclosure" %}
+        <td>{{ run.object_enclosure.name }}</td>
+        {% elif run.object_type == "machine" %}
+        <td>{{ run.object_machine.fqdn }}</td>
+        {% elif run.object_type == "network_interface" %}
+        <td>{{ run.object_network_interface.fqdn }}</td>
+        {% else %}
+        <td>Unkown object name</td>
+        {% endif %}
+      </tr>
+    </tbody>
+  </table>
+
+  <table class="table table-bordered small table-hover">
+    <thead class="thead-default">
+      <th>Property Name</th>
+      <th>Orthos</th>
+      <th>NetBox</th>
+    </thead>
+    <tbody>
+      {% for result in run.results.all %}
+      <tr class="clickable-row" data-href="#{{ result.id }}">
+        <td>{{ result.property_name }}</td>
+        <td>{{ result.orthos_result }}</td>
+        <td>{{ result.netbox_result }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+{% endblock %}

--- a/orthos2/frontend/templates/frontend/netboxorthoscomparison/overview.html
+++ b/orthos2/frontend/templates/frontend/netboxorthoscomparison/overview.html
@@ -1,0 +1,64 @@
+{% extends 'frontend/base.html' %}
+
+{% load static %}
+{% load filters %}
+{% load tags %}
+
+{% block navbar %}
+
+{% include 'frontend/snippet.navlinks.html' %}
+{% include 'frontend/snippet.search.html' %}
+
+{% endblock %}
+
+{% block content %}
+
+<div class="container-fluid">
+  {% if runs %}
+
+  <table class="table table-striped table-bordered table-fixed">
+    <thead class="thead-default">
+      <tr style="border: 1px solid #ddd">
+        <th>UUID {% order_list request 'run_id' %}</th>
+        <th>Run at {% order_list request 'compare_timestamp' %}</th>
+        <th>Object Type {% order_list request 'object_type' %}</th>
+        <th>Object Name</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for run in runs %}
+      <tr>
+        <th>
+          <a
+            href="{% url 'frontend:compare_netbox_details' run.run_id %}"
+            class="text-muted"
+          >
+            {{ run.run_id }}
+          </a>
+        </th>
+        <th>{{ run.compare_timestamp }}</th>
+        <th>{{ run.object_type }}</th>
+        {% if run.object_type == "bmc" %}
+        <th>{{ run.object_bmc.fqdn }}</th>
+        {% elif run.object_type == "enclosure" %}
+        <th>{{ run.object_enclosure.name }}</th>
+        {% elif run.object_type == "machine" %}
+        <th>{{ run.object_machine.fqdn }}</th>
+        {% elif run.object_type == "network_interface" %}
+        <th>{{ run.object_network_interface.fqdn }}</th>
+        {% else %}
+        <th>Unkown object name</td>
+        {% endif %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {% else %}
+
+  <div class="alert alert-info">No NetBox Orthos comparison runs found!</div>
+
+  {% endif %} {% include 'frontend/snippet.paginator.html' %}
+</div>
+
+{% endblock %}

--- a/orthos2/frontend/templates/frontend/snippet.navlinks.html
+++ b/orthos2/frontend/templates/frontend/snippet.navlinks.html
@@ -23,4 +23,9 @@
     <a class="nav-link" href="{% url 'frontend:machine_add' %}">Add Machine</a>
   </li>
   {% endif %}
+  {% if perms.data and perms.data.add_netboxorthoscomparisonrun  %}
+  <li class="nav-item {% active_view request 'compare_netbox_overview' %}">
+    <a class="nav-link" href="{% url 'frontend:compare_netbox_overview' %}">NetBox Comparisons</a>
+  </li>
+  {% endif %}
 </ul>

--- a/orthos2/frontend/urls.py
+++ b/orthos2/frontend/urls.py
@@ -133,4 +133,14 @@ urlpatterns = [
         views.regenerate.regenerate_machine_motd,
         name="regenerate_machine_motd",
     ),
+    re_path(
+        r"^compare-netbox/overview",
+        views.NetboxOrthosComparisionRunListView.as_view(),
+        name="compare_netbox_overview",
+    ),
+    re_path(
+        r"^compare-netbox/(?P<id>[a-z0-9\-]+)$",
+        views.netboxorthoscomparisonrun,
+        name="compare_netbox_details",
+    ),
 ]

--- a/orthos2/frontend/views/__init__.py
+++ b/orthos2/frontend/views/__init__.py
@@ -2,10 +2,88 @@
 This module contains all Django frontend views. For convenience, they are all reexported.
 """
 
-from .ajax import *  # noqa: F401
-from .auth import *  # noqa: F401
-from .machine import *  # noqa: F401
-from .machines import *  # noqa: F401
-from .regenerate import *  # noqa: F401
-from .statistics import *  # noqa: F401
-from .user import *  # noqa: F401
+from .ajax import annotation, powercycle, virtualization_delete, virtualization_list
+from .auth import deprecate_current_app, login
+from .machine import (
+    compare_netbox,
+    console,
+    cpu,
+    fetch_netbox,
+    history,
+    installations,
+    machine,
+    machine_add,
+    machine_netboxcomparision,
+    machine_release,
+    machine_reserve,
+    misc,
+    networkinterfaces,
+    pci,
+    rescan,
+    scsi,
+    setup,
+    usb,
+    virtualization,
+    virtualization_add,
+)
+from .machines import (
+    AllMachineListView,
+    FreeMachineListView,
+    MachineListView,
+    MyMachineListView,
+    VirtualMachineListView,
+    machine_search,
+)
+from .regenerate import (
+    regenerate_cobbler,
+    regenerate_domain_cobbler,
+    regenerate_domain_cscreen,
+    regenerate_machine_cobbler,
+    regenerate_machine_motd,
+)
+from .statistics import statistics
+from .user import users_create, users_password_restore, users_preferences
+
+__all__ = [
+    "annotation",
+    "powercycle",
+    "virtualization_list",
+    "virtualization_delete",
+    "deprecate_current_app",
+    "login",
+    "pci",
+    "cpu",
+    "networkinterfaces",
+    "installations",
+    "usb",
+    "scsi",
+    "virtualization",
+    "virtualization_add",
+    "misc",
+    "machine_reserve",
+    "machine_release",
+    "history",
+    "rescan",
+    "setup",
+    "console",
+    "machine",
+    "machine_netboxcomparision",
+    "fetch_netbox",
+    "compare_netbox",
+    "machine_add",
+    "MachineListView",
+    "AllMachineListView",
+    "MyMachineListView",
+    "FreeMachineListView",
+    "VirtualMachineListView",
+    "machine_search",
+    "regenerate_cobbler",
+    "regenerate_domain_cscreen",
+    "regenerate_domain_cobbler",
+    "regenerate_machine_motd",
+    "regenerate_machine_cobbler",
+    "statistics",
+    "users_create",
+    "users_password_restore",
+    "users_preferences",
+]

--- a/orthos2/frontend/views/__init__.py
+++ b/orthos2/frontend/views/__init__.py
@@ -4,6 +4,10 @@ This module contains all Django frontend views. For convenience, they are all re
 
 from .ajax import annotation, powercycle, virtualization_delete, virtualization_list
 from .auth import deprecate_current_app, login
+from .compare_netbox import (
+    NetboxOrthosComparisionRunListView,
+    netboxorthoscomparisonrun,
+)
 from .machine import (
     compare_netbox,
     console,
@@ -51,6 +55,8 @@ __all__ = [
     "virtualization_delete",
     "deprecate_current_app",
     "login",
+    "NetboxOrthosComparisionRunListView",
+    "netboxorthoscomparisonrun",
     "pci",
     "cpu",
     "networkinterfaces",

--- a/orthos2/frontend/views/compare_netbox.py
+++ b/orthos2/frontend/views/compare_netbox.py
@@ -1,0 +1,95 @@
+"""
+This view module contains all views that display the NetboxOrthosComparisionRun model and its detailed results.
+"""
+
+import uuid
+from typing import TYPE_CHECKING, Any, Dict
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.http import HttpRequest, HttpResponseBase
+from django.shortcuts import redirect, render
+from django.utils.decorators import method_decorator  # type: ignore
+from django.views.generic import ListView
+
+from orthos2.data.models.netboxorthoscomparision import NetboxOrthosComparisionRun
+
+if TYPE_CHECKING:
+    from orthos2.types import AuthenticatedHttpRequest
+
+
+class NetboxOrthosComparisionRunListView(PermissionRequiredMixin, ListView):
+    model = NetboxOrthosComparisionRun
+    template_name = "frontend/netboxorthoscomparison/overview.html"
+    permission_required = "data.change_netboxorthoscomparisonrun"
+    paginate_by = 50
+
+    # login is required for all machine lists
+    @method_decorator(login_required)
+    def dispatch(
+        self, request: HttpRequest, *args: Any, **kwargs: Any
+    ) -> HttpResponseBase:
+        return super(NetboxOrthosComparisionRunListView, self).dispatch(
+            request, *args, **kwargs
+        )
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        context = super(NetboxOrthosComparisionRunListView, self).get_context_data(**kwargs)  # type: ignore
+        context["run_list"] = self.object_list  # type: ignore
+
+        order_by = self.request.GET.get("order_by", None)
+        order_direction = self.request.GET.get("order_direction", None)
+        if order_by and order_direction in {"asc", "desc"}:
+            context["run_list"] = self.object_list.order_by(  # type: ignore
+                "{}".format(order_by)
+                if order_direction == "asc"
+                else "-{}".format(order_by)
+            )
+            # hit the DB to check order_by fields and restore the queryset if something fails
+            try:
+                context["run_list"] = list(context["run_list"])  # type: ignore
+            except KeyError:
+                context["run_list"] = self.object_list  # type: ignore
+
+        paginator = Paginator(context["run_list"], self.paginate_by)  # type: ignore
+
+        page = self.request.GET.get("page", 1)
+
+        try:
+            comparison_runs = paginator.page(page)  # type: ignore
+        except PageNotAnInteger:
+            comparison_runs = paginator.page(1)  # type: ignore
+        except EmptyPage:
+            comparison_runs = paginator.page(paginator.num_pages)  # type: ignore
+
+        context["title"] = "NetBox Comparison Runs"
+        context["runs"] = comparison_runs
+        return context
+
+
+@login_required
+@permission_required("data.change_netboxorthoscomparisonrun")
+def netboxorthoscomparisonrun(
+    request: "AuthenticatedHttpRequest", id: str
+) -> HttpResponseBase:
+    try:
+        uuid.UUID(id)
+    except ValueError:
+        messages.error(request, "NetboxOrthosComparisonRun does not exist.")
+        return redirect("frontend:compare_netbox_overview")
+    try:
+        requested_run = NetboxOrthosComparisionRun.objects.get(pk=id)
+    except NetboxOrthosComparisionRun.DoesNotExist:
+        messages.error(request, "NetboxOrthosComparisonRun does not exist.")
+        return redirect("frontend:compare_netbox_overview")
+
+    return render(
+        request,
+        "frontend/netboxorthoscomparison/details.html",
+        {
+            "run": requested_run,
+            "title": "NetBox Comparison Run",
+        },
+    )


### PR DESCRIPTION
This PR is adding a UI to explore the `NetboxOrthosComparisonRun` model instances.

Since the model instances are deleted after a two-week retention time, no deletion options are needed. As the results are auto-generated and no user input is needed, no add and change views are required.

Overview Screenshot:

<img width="1906" height="229" alt="image" src="https://github.com/user-attachments/assets/c8368c95-137a-4c44-ac35-e6a4ca88b60f" />

Detail Screenshot:

<img width="1915" height="471" alt="image" src="https://github.com/user-attachments/assets/edefc594-4e78-4e84-b09c-7b351343f69d" />
