### PR TITLE
Frontend: Fix stacktraces in the logs of orthos-testing

### DIFF
--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -163,6 +163,7 @@ class BMCInline(admin.StackedInline):  # type: ignore
     extra = 0
     formset = BMCFormInlineFormSet
     form = BMCForm
+    readonly_fields = ("netbox_last_fetch_attempt",)
 
     def get_formset(  # type: ignore
         self, request: HttpRequest, obj: Optional["Machine"] = None, **kwargs: Any

--- a/orthos2/data/models/remotepower.py
+++ b/orthos2/data/models/remotepower.py
@@ -233,7 +233,7 @@ class RemotePower(models.Model):
         """
         password = None
         username = None
-        fence = self.fence_agent
+        fence = self.get_remotepower_fence()
         if not fence:
             raise ValueError("No fence agent set for remote power object")
         if fence.device == "bmc":

--- a/orthos2/data/models/serverconfig.py
+++ b/orthos2/data/models/serverconfig.py
@@ -38,8 +38,8 @@ class ServerConfigManager(models.Manager["ServerConfig"]):
         try:
             obj = ServerConfig.objects.get(key=key)
             return obj.value.lower() == "bool:true"
-        except ServerConfig.DoesNotExist as e:
-            logger.warning('Key "%s" did not exist, returning fallback value', key, e)
+        except ServerConfig.DoesNotExist:
+            logger.warning('Key "%s" did not exist, returning fallback value', key)
             return fallback
 
     def list_by_key(self, key: str, delimiter: str = ",") -> Optional[List[str]]:


### PR DESCRIPTION
- Remotepower: Get the credentials of the currently choosen fence agent.
- Serverconfig: Remove the unused exception trace from the log message
- Admin: Make the Last Fetched at timestamp read-only