### PR TITLE
CLI: Remove manpage from RPM-SPEC

### DIFF
--- a/cli/orthos-client.spec
+++ b/cli/orthos-client.spec
@@ -51,7 +51,6 @@ install cli/orthosrc %{buildroot}/%{_sysconfdir}/orthosrc
 %files
 %attr(755, root, root) %{_bindir}/orthos2
 %config %attr(644, root, root) %{_sysconfdir}/orthosrc
-%{_mandir}/man1/orthos2.1*
 
 %changelog
 * Tue Sep 15 00:26:20 UTC 2020 - Thomas Renninger <trenn@suse.de>


### PR DESCRIPTION
Fixes the build issue inside the OBS.

```
[   12s] Executing(%install): /usr/bin/bash -e /var/tmp/rpm-tmp.HHKfWP
[   12s] + umask 022
[   12s] + cd /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build
[   12s] + /usr/bin/rm -rf /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT
[   12s] + /usr/bin/mkdir -p /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build
[   12s] + /usr/bin/mkdir /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT
[   12s] + cd orthos2-1.5.169+git.8afc7d4
[   12s] + mkdir -p /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT//usr/bin
[   12s] + mkdir -p /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT//etc
[   12s] + mkdir -p /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT//usr/share/man/man1
[   12s] + install cli/orthos2 /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT//usr/bin/orthos2
[   12s] + install cli/orthosrc /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT//etc/orthosrc
[   12s] + /usr/lib/rpm/brp-compress
[   12s] + /usr/lib/rpm/brp-suse
[   12s] calling /usr/lib/rpm/brp-suse.d/brp-05-permissions
[   12s] calling /usr/lib/rpm/brp-suse.d/brp-15-strip-debug
[   12s] calling /usr/lib/rpm/brp-suse.d/brp-25-symlink
[   12s] calling /usr/lib/rpm/brp-suse.d/brp-50-generate-fips-hmac
[   12s] calling /usr/lib/rpm/brp-suse.d/brp-75-ar
[   12s] SOURCE_DATE_EPOCH is not set: skipping ar normalization
[   12s] Processing files: orthos-client-1.5.169+git.8afc7d4-62.1.noarch
[   12s] error: File not found: /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT/usr/share/man/man1/orthos2.1*
[   12s] 
[   12s] RPM build errors:
[   12s]     File not found: /home/abuild/rpmbuild/BUILD/orthos-client-1.5.169+git.8afc7d4-build/BUILDROOT/usr/share/man/man1/orthos2.1*
```