### PR TITLE
API: Fix serializing machines with remote power

### DIFF
--- a/orthos2/api/fixtures/serializers/machines.json
+++ b/orthos2/api/fixtures/serializers/machines.json
@@ -128,5 +128,83 @@
       "updated": "2016-01-01T10:00:00+00:00",
       "created": "2016-01-01T10:00:00+00:00"
     }
+  },
+  {
+    "model": "data.bmc",
+    "pk": 1,
+    "fields": {
+      "username": "root",
+      "password": "root",
+      "fqdn": "testsys-sp.orthos2.test",
+      "mac": "AA:BB:CC:DD:EE:FF",
+      "machine": 2,
+      "fence_agent": 1
+    }
+  },
+  {
+    "model": "data.machine",
+    "pk": 2,
+    "fields": {
+      "enclosure": 1,
+      "fqdn": "testsys.orthos2.test",
+      "system": 1,
+      "comment": "",
+      "serial_number": "",
+      "product_code": "",
+      "architecture": 1,
+      "fqdn_domain": 1,
+      "cpu_model": "",
+      "cpu_flags": "",
+      "cpu_physical": 1,
+      "cpu_cores": 1,
+      "cpu_threads": 1,
+      "cpu_speed": "0.00",
+      "cpu_id": "",
+      "ram_amount": 0,
+      "efi": false,
+      "nda": true,
+      "ipmi": false,
+      "vm_capable": false,
+      "vm_max": 5,
+      "vm_dedicated_host": false,
+      "vm_auto_delete": false,
+      "reserved_until": "9999-12-31T23:59:59.999+00:00",
+      "reserved_reason": "test HOS",
+      "platform": null,
+      "bios_version": "",
+      "bios_date": "2010-10-10",
+      "disk_primary_size": null,
+      "disk_type": "",
+      "lsmod": "",
+      "last": "",
+      "hwinfo": "",
+      "dmidecode": "",
+      "dmesg": "",
+      "lsscsi": "",
+      "lsusb": "",
+      "lspci": "",
+      "status_ipv4": true,
+      "status_ipv6": true,
+      "status_ssh": true,
+      "status_login": false,
+      "administrative": false,
+      "check_connectivity": 3,
+      "collect_system_information": true,
+      "dhcp_filename": null,
+      "active": true,
+      "group": null,
+      "contact_email": "",
+      "tftp_server": 1,
+      "updated": "2017-11-17T15:36:51.499Z",
+      "created": "2017-10-24T14:20:37.298Z"
+    }
+  },
+  {
+    "model": "data.remotepower",
+    "fields": {
+      "fence_agent": 1,
+      "options": "",
+      "machine": 2
+    }
   }
 ]

--- a/orthos2/api/serializers/machine.py
+++ b/orthos2/api/serializers/machine.py
@@ -63,6 +63,9 @@ class BMCListingField(BMCSerializer):
 
         for name, field in self.fields.items():  # type: ignore
             value = getattr(instance, str(name))
+            if name == "fence_agent":
+                result[name] = {"label": field.label, "value": value.name}
+                continue
             result[name] = {"label": field.label, "value": value}
         return result
 

--- a/orthos2/api/tests/commands/test_info.py
+++ b/orthos2/api/tests/commands/test_info.py
@@ -43,3 +43,30 @@ class InfoTest(APITestCase):
             json_response["data"]["reserved_until"]["value"],
             ("9999-12-31T22:59:59.999999+01:00", "9999-12-31T23:59:59.999999+01:00"),
         )
+
+    def test_info_get_remote_power(self) -> None:
+        """
+        Verify that retrieving a machine with an infinite reservation is possible.
+        """
+        # Arrange
+        url = reverse("api:machine")
+        url += "?fqdn=testsys.orthos2.test"
+        self.maxDiff = None
+
+        # Act
+        response = self.client.get(url, format="json")
+        json_response = response.json()
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue("data" in json_response)
+        self.assertTrue("header" in json_response)
+        self.assertTrue("type" in json_response["header"])
+        self.assertEqual(json_response["header"]["type"], "INFO")
+        self.assertIn(
+            json_response["data"]["reserved_until"]["value"],
+            ("9999-12-31T22:59:59.999999+01:00", "9999-12-31T23:59:59.999999+01:00"),
+        )
+        self.assertEqual(
+            json_response["data"]["bmc"]["value"]["fence_agent"]["value"], "Dummy BMC"
+        )

--- a/orthos2/api/tests/serializers/test_machine.py
+++ b/orthos2/api/tests/serializers/test_machine.py
@@ -27,3 +27,17 @@ class MachineSerializerTest(TestCase):
 
         # Assert
         self.assertNotEqual(result, {})
+
+    def test_machine_serialization_with_remote_power(self):
+        """
+        Verify that serializing machines with remote power is working as expected.
+        """
+        # Arrange
+        machine = Machine.objects.get(pk=2)
+        serializer = MachineSerializer(machine)
+
+        # Act
+        result = serializer.data_info
+
+        # Assert
+        self.assertNotEqual(result, {})


### PR DESCRIPTION
This PR fixes the following stacktrace (caused in #348):

```
Aug 19 06:45:54 orthos2 gunicorn[31544]: Internal Server Error: /api/machine
Aug 19 06:45:54 orthos2 gunicorn[31544]: Traceback (most recent call last):
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
Aug 19 06:45:54 orthos2 gunicorn[31544]:     response = get_response(request)
Aug 19 06:45:54 orthos2 gunicorn[31544]:                ^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
Aug 19 06:45:54 orthos2 gunicorn[31544]:     response = wrapped_callback(request, *callback_args, **callback_kwargs)
Aug 19 06:45:54 orthos2 gunicorn[31544]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
Aug 19 06:45:54 orthos2 gunicorn[31544]:     return view_func(*args, **kwargs)
Aug 19 06:45:54 orthos2 gunicorn[31544]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/django/views/generic/base.py", line 105, in view
Aug 19 06:45:54 orthos2 gunicorn[31544]:     return self.dispatch(request, *args, **kwargs)
Aug 19 06:45:54 orthos2 gunicorn[31544]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
Aug 19 06:45:54 orthos2 gunicorn[31544]:     response = self.handle_exception(exc)
Aug 19 06:45:54 orthos2 gunicorn[31544]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
Aug 19 06:45:54 orthos2 gunicorn[31544]:     self.raise_uncaught_exception(exc)
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
Aug 19 06:45:54 orthos2 gunicorn[31544]:     raise exc
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
Aug 19 06:45:54 orthos2 gunicorn[31544]:     response = handler(request, *args, **kwargs)
Aug 19 06:45:54 orthos2 gunicorn[31544]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/orthos2/api/commands/info.py", line 151, in get
Aug 19 06:45:54 orthos2 gunicorn[31544]:     return JsonResponse(response)
Aug 19 06:45:54 orthos2 gunicorn[31544]:            ^^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/django/http/response.py", line 731, in __init__
Aug 19 06:45:54 orthos2 gunicorn[31544]:     data = json.dumps(data, cls=encoder, **json_dumps_params)
Aug 19 06:45:54 orthos2 gunicorn[31544]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib64/python3.11/json/__init__.py", line 238, in dumps
Aug 19 06:45:54 orthos2 gunicorn[31544]:     **kw).encode(obj)
Aug 19 06:45:54 orthos2 gunicorn[31544]:           ^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib64/python3.11/json/encoder.py", line 200, in encode
Aug 19 06:45:54 orthos2 gunicorn[31544]:     chunks = self.iterencode(o, _one_shot=True)
Aug 19 06:45:54 orthos2 gunicorn[31544]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib64/python3.11/json/encoder.py", line 258, in iterencode
Aug 19 06:45:54 orthos2 gunicorn[31544]:     return _iterencode(o, 0)
Aug 19 06:45:54 orthos2 gunicorn[31544]:            ^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib/python3.11/site-packages/django/core/serializers/json.py", line 106, in default
Aug 19 06:45:54 orthos2 gunicorn[31544]:     return super().default(o)
Aug 19 06:45:54 orthos2 gunicorn[31544]:            ^^^^^^^^^^^^^^^^^^
Aug 19 06:45:54 orthos2 gunicorn[31544]:   File "/usr/lib64/python3.11/json/encoder.py", line 180, in default
Aug 19 06:45:54 orthos2 gunicorn[31544]:     raise TypeError(f'Object of type {o.__class__.__name__} '
Aug 19 06:45:54 orthos2 gunicorn[31544]: TypeError: Object of type RemotePowerType is not JSON serializable
```