### PR TITLE
Docker: Fix HTTPS access for Orthos 2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           pylint --rcfile=.pylintrc --fail-under=10 cli/orthos2
           pylint --rcfile=.pylintrc --fail-under=10 cli/tests
-  pycodingstyle:
+  flake8:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
@@ -124,10 +124,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pycodestyle
-      - name: Analysing the code with pycodestyle
+          python -m pip install flake8
+      - name: Analysing the code with flake8
         run: |
-          pycodestyle .
+          flake8 orthos2
   django-admin:
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10
+        language_version: python3.11
         additional_dependencies: ['click==8.0.4']
   - repo: https://github.com/pycqa/isort
     # Configuration for isort is in "pyproject.toml"

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -3,9 +3,12 @@ services:
     hostname: netbox.orthos2.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.netbox.rule=Host(`netbox.orthos2.test`)"
-      - "traefik.http.routers.netbox.entrypoints=web,websecure"
+      - "traefik.http.routers.netbox-http.rule=Host(`netbox.orthos2.test`)"
+      - "traefik.http.routers.netbox-http.entrypoints=web"
+      - "traefik.http.routers.netbox-https.rule=Host(`netbox.orthos2.test`)"
+      - "traefik.http.routers.netbox-https.entrypoints=websecure"
+      - "traefik.http.routers.netbox-https.tls=true"
       - "traefik.http.services.netbox.loadbalancer.server.port=8080"
       - "traefik.http.middlewares.netbox-static-fix.replacepathregex.regex=^/(.*)/static/"
       - "traefik.http.middlewares.netbox-static-fix.replacepathregex.replacement=/static/"
-      - "traefik.http.routers.netbox.middlewares=netbox-static-fix"
+      - "traefik.http.routers.netbox-https.middlewares=netbox-static-fix"

--- a/compose.yaml
+++ b/compose.yaml
@@ -43,8 +43,13 @@ services:
       retries: 5
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.orthos2.rule=Host(`orthos2.orthos2.test`)"
-      - "traefik.http.routers.orthos2.entrypoints=web,websecure"
+      - "traefik.http.routers.orthos2-http.rule=Host(`orthos2.orthos2.test`)"
+      - "traefik.http.routers.orthos2-http.entrypoints=web"
+      - "traefik.http.routers.orthos2-http.middlewares=orthos2-https"
+      - "traefik.http.middlewares.orthos2-https.redirectScheme.scheme=https"
+      - "traefik.http.routers.orthos2-https.rule=Host(`orthos2.orthos2.test`)"
+      - "traefik.http.routers.orthos2-https.entrypoints=websecure"
+      - "traefik.http.routers.orthos2-https.tls=true"
       - "traefik.http.services.orthos2.loadbalancer.server.port=8000"
   orthos2_taskmanager:
     build:
@@ -85,8 +90,11 @@ services:
       dockerfile: cobbler.dockerfile
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.cobbler.rule=Host(`cobbler.orthos2.test`)"
-      - "traefik.http.routers.cobbler.entrypoints=web,websecure"
+      - "traefik.http.routers.cobbler-http.rule=Host(`cobbler.orthos2.test`)"
+      - "traefik.http.routers.cobbler-http.entrypoints=web"
+      - "traefik.http.routers.cobbler-https.rule=Host(`cobbler.orthos2.test`)"
+      - "traefik.http.routers.cobbler-https.entrypoints=websecure"
+      - "traefik.http.routers.cobbler-https.tls=true"
       - "traefik.http.services.cobbler.loadbalancer.server.port=80"
   serial_console:
     hostname: sconsole.orthos2.test
@@ -113,7 +121,7 @@ services:
       redis-cache:
         condition: service_healthy
     env_file: docker/netbox/netbox.env
-    user: "unit:root"
+    user: "netbox:root"
     volumes:
       - ./docker/netbox/test_config.py:/etc/netbox/config/test_config.py:z,ro
     healthcheck:

--- a/docker/manage-secrets.py
+++ b/docker/manage-secrets.py
@@ -115,4 +115,8 @@ orthos_superuser_password = get_random_string(12)
     'ORTHOS2_POSTGRES_NAME="orthos"\n'
     'ORTHOS2_POSTGRES_USER="orthos"\n'
     f'ORTHOS2_POSTGRES_PASSWORD="{orthos_db_password}"\n'
+    'ALLOWED_HOSTS="orthos2.orthos2.test"\n'
+    'CSRF_TRUSTED_ORIGINS="https://orthos2.orthos2.test"\n'
+    'CSRF_ALLOWED_ORIGIN="https://orthos2.orthos2.test"\n'
+    'CROSS_ORIGINS_WHITELIST="https://orthos2.orthos2.test"\n',
 )

--- a/orthos2/api/urls.py
+++ b/orthos2/api/urls.py
@@ -4,7 +4,7 @@ from django.urls import re_path
 from rest_framework.authtoken import views as authtoken_views
 
 from orthos2.api import views
-from orthos2.api.commands import *
+from orthos2.api.commands import *  # noqa: F403
 
 app_name = "api"
 urlpatterns = [
@@ -28,11 +28,11 @@ urlpatterns += AddVMCommand.get_urls()  # noqa: F405
 urlpatterns += AddMachineCommand.get_urls()  # noqa: F405
 urlpatterns += AddSerialConsoleCommand.get_urls()  # noqa: F405
 urlpatterns += AddAnnotationCommand.get_urls()  # noqa: F405
-urlpatterns += AddBMCCommand.get_urls()
+urlpatterns += AddBMCCommand.get_urls()  # noqa: F405
 urlpatterns += AddRemotePowerCommand.get_urls()  # noqa: F405
-urlpatterns += AddRemotePowerDeviceCommand.get_urls()
+urlpatterns += AddRemotePowerDeviceCommand.get_urls()  # noqa: F405
 urlpatterns += DeleteCommand.get_urls()  # noqa: F405
 urlpatterns += DeleteMachineCommand.get_urls()  # noqa: F405
 urlpatterns += DeleteSerialConsoleCommand.get_urls()  # noqa: F405
 urlpatterns += DeleteRemotePowerCommand.get_urls()  # noqa: F405
-urlpatterns += DeleteRemotePowerDeviceCommand.get_urls()  # noda: F405
+urlpatterns += DeleteRemotePowerDeviceCommand.get_urls()  # noqa: F405

--- a/orthos2/data/admin.py
+++ b/orthos2/data/admin.py
@@ -96,7 +96,7 @@ class BMCForm(forms.ModelForm):  # type: ignore
         Called during self.clean(). Suggests an IP address in case a MAC is present.
         """
         bmc_domain = Domain.objects.get(name=get_domain(self.cleaned_data["fqdn"]))
-        interface_mac = self.cleaned_data.get(f"mac")
+        interface_mac = self.cleaned_data.get("mac")
         if interface_mac == "":
             # We don't want to autogenerate an address for interfaces without MAC addresses
             self.cleaned_data["ip_address_v4"] = ""
@@ -312,7 +312,7 @@ class NetworkInterfaceForm(forms.ModelForm):  # type: ignore
         if not interface_machine:
             raise forms.ValidationError("Cannot retrieve machine for interface!")
         machine_domain = Domain.objects.get(name=get_domain(interface_machine.fqdn))
-        interface_mac = self.cleaned_data.get(f"mac_address")
+        interface_mac = self.cleaned_data.get("mac_address")
         if interface_mac == "":
             # We don't want to autogenerate an address for interfaces without MAC addresses
             self.cleaned_data["ip_address_v4"] = ""

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
     from django.db.models.fields.related_descriptors import RelatedManager
 
     from orthos2.data.models.annotation import Annotation
-    from orthos2.data.models.bmc import BMC
     from orthos2.data.models.installation import Installation
     from orthos2.data.models.remotepower import RemotePower
     from orthos2.data.models.reservationhistory import ReservationHistory
@@ -1055,7 +1054,7 @@ class Machine(models.Model):
                     update_machine = True
 
             if self.fqdn_domain != self._original.fqdn_domain:
-                logger.info(f"Domain change for: %s", self.fqdn)
+                logger.info("Domain change for: %s", self.fqdn)
                 # TODO: add error handling (checking whether the signal went through)
                 # Not removing the machine from the original Cobbler system, because there is no easy remove signal
                 # and it's probably not even necessary

--- a/orthos2/data/validators.py
+++ b/orthos2/data/validators.py
@@ -1,6 +1,5 @@
 import validators  # type: ignore
 from django.core.exceptions import ValidationError
-from django.utils.translation import gettext_lazy as _
 
 
 def validate_mac_address(mac_address: str) -> None:

--- a/orthos2/settings.py
+++ b/orthos2/settings.py
@@ -14,9 +14,41 @@ import logging
 import logging.config
 import os
 import sys
-from socket import getfqdn, gethostname
+from typing import Any, Callable, Optional
 
 from django.contrib.messages import constants as messages
+
+
+# START: Taken from NetBox Docker Repository
+# If the `map_fn` isn't defined, then the value that is read from the environment (or the default value if not found)
+# is returned.
+# If the `map_fn` is defined, then `map_fn` is invoked and the value (that was read from the environment or the default
+# value if not found) is passed to it as a parameter. The value returned from `map_fn` is then the return value of this
+# function.
+# The `map_fn` is not invoked, if the value (that was read from the environment or the default value if not found)
+# is None.
+def _environ_get_and_map(
+    variable_name: str,
+    default: str | None = None,
+    map_fn: Optional[Callable[[str], Optional[Any]]] = None,
+) -> Any | None:
+    env_value = os.environ.get(variable_name, default)
+
+    if env_value is None:
+        return env_value
+
+    if not map_fn:
+        return env_value
+
+    return map_fn(env_value)
+
+
+_AS_BOOL = lambda value: value.lower() == "true"  # noqa: E731
+_AS_INT = lambda value: int(value)  # noqa: E731
+_AS_LIST: Callable[[str], Optional[Any]] = lambda value: list(
+    filter(None, value.split(" "))
+)
+# END: Taken from NetBox Docker Repository
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.abspath("/var/lib/orthos2")
@@ -30,7 +62,13 @@ SECRET_KEY = os.environ.get("ORTHOS_SECRET_KEY", "")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", gethostname(), getfqdn()]
+ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(" ")
+# ensure that '*' or 'localhost' is always in ALLOWED_HOSTS (needed for health checks)
+if "*" not in ALLOWED_HOSTS and "localhost" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("localhost")
+CSRF_TRUSTED_ORIGINS = _environ_get_and_map("CSRF_TRUSTED_ORIGINS", "", _AS_LIST)
+CSRF_ALLOWED_ORIGIN = _environ_get_and_map("CSRF_ALLOWED_ORIGIN", "", _AS_LIST)
+CROSS_ORIGINS_WHITELIST = _environ_get_and_map("CROSS_ORIGINS_WHITELIST", "", _AS_LIST)
 
 # Application definition
 

--- a/orthos2/taskmanager/tasks/sconsole.py
+++ b/orthos2/taskmanager/tasks/sconsole.py
@@ -25,7 +25,7 @@ class RegenerateSerialConsole(Task):
             return
 
         try:
-            _cscreen_server = Machine.objects.get(fqdn=self.fqdn)
+            Machine.objects.get(fqdn=self.fqdn)
         except Machine.DoesNotExist:
             logger.warning("Serial console server does not exist: %s", self.fqdn)
 

--- a/orthos2/utils/netbox.py
+++ b/orthos2/utils/netbox.py
@@ -46,7 +46,7 @@ class REST:
         r = self.s.send(prepared_request)
         if r.status_code != 201:
             logger.warning(
-                f"HTTP Response: %s - %s - %s", r.status_code, r.reason, r.text
+                "HTTP Response: %s - %s - %s", r.status_code, r.reason, r.text
             )
         r.raise_for_status()
 
@@ -62,7 +62,7 @@ class REST:
         r = self.s.send(prepared_request)
         if r.status_code != 200:
             logger.warning(
-                f"HTTP Response: %s - %s - %s", r.status_code, r.reason, r.text
+                "HTTP Response: %s - %s - %s", r.status_code, r.reason, r.text
             )
         r.raise_for_status()
 
@@ -79,7 +79,7 @@ class REST:
 
         if r.status_code != 200:
             logger.warning(
-                f"HTTP Response: %s - %s - %s", r.status_code, r.reason, r.text
+                "HTTP Response: %s - %s - %s", r.status_code, r.reason, r.text
             )
         r.raise_for_status()
 
@@ -95,7 +95,7 @@ class REST:
         r = self.s.send(prepared_request)
         if r.status_code != 204:
             logger.warning(
-                f"HTTP Response: %s - %s - %s", r.status_code, r.reason, r.text
+                "HTTP Response: %s - %s - %s", r.status_code, r.reason, r.text
             )
         r.raise_for_status()
 

--- a/orthos2/utils/ssh.py
+++ b/orthos2/utils/ssh.py
@@ -265,7 +265,7 @@ class SSH(object):
             directories = directory.lstrip("/").split("/")  # type: ignore
 
             for i, _part in enumerate(directories):
-                directory = "/" + "/".join(directories[0 : i + 1])
+                directory = "/" + "/".join(directories[0 : i + 1])  # noqa: E203
                 try:
                     self._sftp.chdir(directory)
                 except FileNotFoundError:

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,5 @@
-[pycodestyle]
-max-line-length = 120
-# Make pycodestyle & black interoperable
-# https://github.com/psf/black/issues/354#issuecomment-397685631
-ignore = E203,W503
-statistics = True
-exclude =
-    orthos2/data/migrations/*,
-    orthos2/taskmanager/migrations/*
-
 [flake8]
-max-line-length = 100
+max-line-length = 120
 exclude = 
     orthos2/data/migrations/*,
     orthos2/taskmanager/migrations/*,


### PR DESCRIPTION
This fixes an issue with the development environment that made the Orthos 2 Web UI inaccessible.

The issue was that the required settings in Orthos 2 for HTTPS were not set, and the labels in the compose file were incorrect. The old configuration tried listening on HTTP via the HTTPS port.