### PR TITLE
Add UI Action to deactivate IPMI SOL sessions

### DIFF
--- a/docs/adminguide/setup.rst
+++ b/docs/adminguide/setup.rst
@@ -96,4 +96,9 @@ the manual setup of a cscreen server. Follow these steps to ensure that Orthos c
 
 3. Setup passwordless SSH keys between the ``orthos`` (Orthos server) to the ``_cscreen`` user (console server).
 
+.. note:: Orthos can pass environment variables to remote commands via Paramiko ``exec_command``.
+          See `Paramiko SSHClient.exec_command docs <https://docs.paramiko.org/en/stable/api/client.html#paramiko.client.SSHClient.exec_command>`_.
+          SSH servers may silently reject environment variables, so do not rely on them unless the server-side
+          SSH daemon is configured to accept them.
+
 4. Enable and start the systemd service for cscreen ``systemctl enable --now cscreend.service``

--- a/docs/userguide/machine_page.rst
+++ b/docs/userguide/machine_page.rst
@@ -60,6 +60,8 @@ Machine Actions
 - Setup Machine: Here you can install your machine according to your needs. You have the possibility to install SLES, 
   SLED, Opensuse Leap, Opensuse and Tumbleweed. During the installation you have several options: install, install ssh
   install ssh auto, install auto etc.
+- Queue SOL Deactivation: For machines with IPMI serial consoles, this action queues a background task to deactivate
+  Serial-over-LAN (SOL) via the configured serial console server.
 - Report Problem: If you unexpectedly encounter a problem with the machine, you can create a support ticket here.
 
 .. image:: ../img/userguide/10_machine_release.jpg

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -1394,6 +1394,43 @@ class Machine(models.Model):
         return False
 
     @check_permission
+    def deactivate_sol(self, user: Any = None) -> bool:
+        """Queue asynchronous deactivation of the machine Serial-over-LAN session."""
+        from orthos2.data.signals import signal_serialconsole_sol_deactivate
+
+        if not self.has_serialconsole():
+            logger.warning(
+                "SOL deactivate skipped for %s: no serial console available", self.fqdn
+            )
+            return False
+
+        if self.serialconsole.stype.name != "IPMI":
+            logger.warning(
+                "SOL deactivate skipped for %s: serial console type is not IPMI",
+                self.fqdn,
+            )
+            return False
+
+        if not self.has_bmc():
+            logger.warning("SOL deactivate skipped for %s: no BMC available", self.fqdn)
+            return False
+
+        if not self.fqdn_domain.cscreen_server:
+            logger.warning(
+                "SOL deactivate skipped for %s: no serial console server configured for domain %s",
+                self.fqdn,
+                self.fqdn_domain,
+            )
+            return False
+
+        signal_serialconsole_sol_deactivate.send(  # type: ignore
+            sender=Machine,
+            machine_id=self.pk,
+        )
+
+        return True
+
+    @check_permission
     def ssh_shutdown(self, user: Any = None, reboot: bool = False) -> bool:
         """Power off/reboot the machine using SSH."""
         from orthos2.utils.ssh import SSH

--- a/orthos2/data/signals.py
+++ b/orthos2/data/signals.py
@@ -20,6 +20,7 @@ signal_cobbler_regenerate = Signal()
 signal_cobbler_sync_dhcp = Signal()
 signal_cobbler_machine_update = Signal()
 signal_serialconsole_regenerate = Signal()
+signal_serialconsole_sol_deactivate = Signal()
 signal_motd_regenerate = Signal()
 
 
@@ -161,6 +162,15 @@ def regenerate_serialconsole(
     if cscreen_server_fqdn is not None:  # type: ignore[reportUnnecessaryComparison]
         task = tasks.RegenerateSerialConsole(cscreen_server_fqdn)
         TaskManager.add(task)
+
+
+@receiver(signal_serialconsole_sol_deactivate)
+def deactivate_serialconsole_sol(
+    sender: Any, machine_id: int, *args: Any, **kwargs: Any
+) -> None:
+    """Create `DeactivateSerialOverLan()` task here."""
+    task = tasks.DeactivateSerialOverLan(machine_id)
+    TaskManager.add(task)
 
 
 @receiver(signal_cobbler_regenerate)

--- a/orthos2/frontend/templates/frontend/machines/detail/overview.html
+++ b/orthos2/frontend/templates/frontend/machines/detail/overview.html
@@ -55,6 +55,24 @@ function powercycle(action) {
   });
 }
 
+
+function deactivate_sol() {
+  $.ajax({
+    type: 'POST',
+    url: '{% url 'frontend:ajax_deactivate_sol' machine.id %}',
+    beforeSend: function() {
+      // Avoid double-submits while the backend deactivation request is running.
+      $('.deactivate-sol').addClass('disabled')
+    },
+    complete: function() {
+      $('.deactivate-sol').removeClass('disabled')
+    },
+    success: function(data) {
+      showMachineStatusBarMessage(data);
+    },
+  });
+}
+
 function regenerate_domain_cscreen() {
   $.ajax({
     url: '{% url 'frontend:regenerate_domain_cscreen' machine.id %}',

--- a/orthos2/frontend/templates/frontend/machines/detail/snippets/sidebar.html
+++ b/orthos2/frontend/templates/frontend/machines/detail/snippets/sidebar.html
@@ -79,6 +79,13 @@
   <a class="btn btn-secondary btn-sm regenerate-domain-cobbler" href="javascript:void(0);" onclick="regenerate_domain_cobbler()" role="button">Regenerate Cobbler Server</a>
   {% endif %}
 </div>
+
+{% if machine.has_serialconsole and machine.serialconsole.stype.name == "IPMI" %}
+<br/>
+<div class="btn-group-vertical d-flex">
+  <a class="btn btn-secondary btn-sm deactivate-sol" href="javascript:void(0);" onclick="deactivate_sol()" role="button">Queue SOL Deactivation</a>
+</div>
+{% endif %}
 {% endif %}
 
 <hr/>

--- a/orthos2/frontend/tests/admin/test_machine.py
+++ b/orthos2/frontend/tests/admin/test_machine.py
@@ -1,17 +1,41 @@
+from unittest import mock
+
 from django.test import TestCase
-from django_webtest import WebTest  # type: ignore
+
+from orthos2.data.models import Machine
 
 
-class AddMachine(WebTest):
-    def test_add_new_machine(self) -> None:
-        pass
+class DeactivateSolMachineTest(TestCase):
 
+    fixtures = ["orthos2/utils/tests/fixtures/machines.json"]
 
-class EditMachine(TestCase):
+    @mock.patch("orthos2.data.signals.signal_serialconsole_sol_deactivate.send")
+    def test_deactivate_sol_enqueues_task(self, mocked_send: mock.MagicMock) -> None:
+        """The model action should enqueue a task instead of running SOL deactivate inline."""
 
-    pass
+        machine = Machine.objects.get(pk=2)
+        machine.fqdn_domain.__class__.objects.filter(pk=machine.fqdn_domain.pk).update(
+            cscreen_server=machine
+        )
+        machine.refresh_from_db()
 
+        result = machine.deactivate_sol()
 
-class DeleteMachine(TestCase):
+        self.assertTrue(result)
+        mocked_send.assert_called_once_with(
+            sender=Machine,
+            machine_id=machine.pk,
+        )
 
-    pass
+    def test_deactivate_sol_requires_serialconsole(self) -> None:
+        """The model action should return False when no serial console is configured."""
+
+        machine = Machine.objects.get(pk=1)
+
+        self.assertFalse(machine.deactivate_sol())
+
+    def test_deactivate_sol_requires_cscreen_server(self) -> None:
+        """The model action should return False when no serial console server is configured."""
+        machine = Machine.objects.get(pk=2)
+
+        self.assertFalse(machine.deactivate_sol())

--- a/orthos2/frontend/tests/admin/test_machine_views.py
+++ b/orthos2/frontend/tests/admin/test_machine_views.py
@@ -1,9 +1,20 @@
+import json
 from unittest import mock
 
+from django.contrib.auth.models import User
 from django.urls import reverse  # type: ignore
 from django_webtest import WebTest  # type: ignore
 
-from orthos2.data.models import Architecture, Machine, ServerConfig, System
+from orthos2.data.models import (
+    BMC,
+    Architecture,
+    Machine,
+    RemotePowerType,
+    SerialConsole,
+    SerialConsoleType,
+    ServerConfig,
+    System,
+)
 from orthos2.data.models.domain import Domain
 
 
@@ -52,6 +63,34 @@ class ChangeView(WebTest):
 
         m2.save()
 
+        ipmi_fence_agent = RemotePowerType.objects.create(
+            name="ipmilanplus", device="bmc"
+        )
+        ipmi_console_type = SerialConsoleType.objects.create(
+            name="IPMI",
+            command=(
+                "ipmitool -I lanplus -H {{ machine.bmc.fqdn }} "
+                "-U {{ ipmi.user}} -P {{ ipmi.password }} sol activate"
+            ),
+            comment="IPMI",
+        )
+
+        BMC.objects.create(
+            username="root",
+            password="root",
+            fqdn="testsys-sp.orthos2.test",
+            mac="AA:BB:CC:DD:EE:FF",
+            machine=m2,
+            fence_agent=ipmi_fence_agent,
+        )
+        SerialConsole.objects.create(
+            machine=m2,
+            stype=ipmi_console_type,
+            kernel_device="ttyS",
+            kernel_device_num=1,
+            baud_rate=115200,
+        )
+
     def test_visible_fieldsets_non_administrative_systems(self) -> None:
         """Test for fieldsets."""
         # Act
@@ -93,3 +132,50 @@ class ChangeView(WebTest):
         # Assert
         self.assertContains(page, "Add another Serial Console")  # type: ignore
         self.assertContains(page, "Remote Power")  # type: ignore
+
+    def test_deactivate_sol_button_visible_for_ipmi_console(self) -> None:
+        """The machine detail page should expose the SOL deactivate action for IPMI consoles."""
+
+        page = self.app.get(  # type: ignore
+            reverse("frontend:detail", args=["2"]), user="superuser"
+        )
+
+        self.assertContains(page, "Queue SOL Deactivation")  # type: ignore
+
+    def test_deactivate_sol_button_hidden_without_serialconsole(self) -> None:
+        """The machine detail page should not expose the SOL action if no serial console exists."""
+
+        page = self.app.get(  # type: ignore
+            reverse("frontend:detail", args=["1"]), user="superuser"
+        )
+
+        self.assertNotContains(page, "Queue SOL Deactivation")  # type: ignore
+
+    @mock.patch("orthos2.frontend.views.ajax.Machine.deactivate_sol")
+    def test_ajax_deactivate_sol(self, mocked_deactivate_sol: mock.MagicMock) -> None:
+        """The AJAX endpoint should queue the machine action and return a success payload."""
+
+        mocked_deactivate_sol.return_value = True
+        self.client.force_login(User.objects.get(username="superuser"))
+
+        response = self.client.post(reverse("frontend:ajax_deactivate_sol", args=["2"]))
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+        self.assertEqual(payload["cls"], "success")
+        self.assertEqual(
+            payload["message"],
+            "SOL deactivation was queued and will run in the background.",
+        )
+        mocked_deactivate_sol.assert_called_once_with(user=mock.ANY)
+
+    def test_ajax_deactivate_sol_rejects_get(self) -> None:
+        """The SOL deactivation endpoint should reject GET requests."""
+
+        page = self.app.get(  # type: ignore
+            reverse("frontend:ajax_deactivate_sol", args=["2"]),
+            user="superuser",
+            expect_errors=True,
+        )
+
+        self.assertEqual(page.status_int, 405)  # type: ignore[attr-defined]

--- a/orthos2/frontend/urls.py
+++ b/orthos2/frontend/urls.py
@@ -140,6 +140,11 @@ urlpatterns = [
         name="ajax_powercycle",
     ),
     re_path(
+        r"^ajax/machine/(?P<machine_id>[0-9]+)/sol/deactivate$",
+        views.ajax.deactivate_sol,
+        name="ajax_deactivate_sol",
+    ),
+    re_path(
         r"^ajax/machine/(?P<host_id>[0-9]+)/virtualization/list$",
         views.ajax.virtualization_list,
         name="ajax_virtualization_list",

--- a/orthos2/frontend/views/ajax.py
+++ b/orthos2/frontend/views/ajax.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, List
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, JsonResponse
 from django.template.defaultfilters import urlize
+from django.views.decorators.http import require_POST
 
 from orthos2.data.models import Annotation, Machine, RemotePower
 from orthos2.frontend.decorators import check_permissions
@@ -67,6 +68,39 @@ def powercycle(request: HttpRequest, machine_id: int) -> JsonResponse:
             return JsonResponse(
                 {"type": "status", "cls": "danger", "message": "Power cycle failed!"}
             )
+
+    except Machine.DoesNotExist:
+        return JsonResponse(
+            {"type": "status", "cls": "danger", "message": "Machine does not exist!"}
+        )
+    except Exception as e:
+        logger.exception(e)
+        return JsonResponse({"type": "status", "cls": "danger", "message": str(e)})
+
+
+@require_POST
+@login_required
+@check_permissions(key="machine_id")
+def deactivate_sol(request: HttpRequest, machine_id: int) -> JsonResponse:
+    """Deactivate the machine SOL session and return result as JSON."""
+
+    try:
+        machine = Machine.objects.get(pk=machine_id)
+        # Keep queueing logic in the model layer so permissions and validation stay centralized.
+        result = machine.deactivate_sol(user=request.user)
+
+        if result:
+            return JsonResponse(
+                {
+                    "type": "status",
+                    "cls": "success",
+                    "message": "SOL deactivation was queued and will run in the background.",
+                }
+            )
+
+        return JsonResponse(
+            {"type": "status", "cls": "danger", "message": "SOL deactivate failed!"}
+        )
 
     except Machine.DoesNotExist:
         return JsonResponse(

--- a/orthos2/taskmanager/tasks/__init__.py
+++ b/orthos2/taskmanager/tasks/__init__.py
@@ -25,6 +25,7 @@ from .notifications import (
 )
 from .sconsole import RegenerateSerialConsole
 from .setup import SetupMachine
+from .sol import DeactivateSerialOverLan
 
 __all__ = [
     "RegenerateCobbler",
@@ -50,5 +51,6 @@ __all__ = [
     "SendReservationInformation",
     "SendRestoredPassword",
     "RegenerateSerialConsole",
+    "DeactivateSerialOverLan",
     "SetupMachine",
 ]

--- a/orthos2/taskmanager/tasks/sol.py
+++ b/orthos2/taskmanager/tasks/sol.py
@@ -1,0 +1,146 @@
+import ipaddress
+import logging
+import re
+import shlex
+
+from orthos2.data.models import Machine, ServerConfig
+from orthos2.taskmanager.models import Task
+from orthos2.utils.ssh import SSH
+
+logger = logging.getLogger("tasks")
+
+
+class DeactivateSerialOverLan(Task):
+    """Deactivate SOL for a machine from its serial console server."""
+
+    def __init__(self, machine_id: int) -> None:
+        self.machine_id = machine_id
+
+    def execute(self) -> None:
+        timeout_seconds = 30.0
+
+        try:
+            machine = Machine.objects.get(pk=self.machine_id)
+        except Machine.DoesNotExist:
+            logger.error("Machine does not exist: id=%s", self.machine_id)
+            return
+
+        if (
+            not machine.has_serialconsole()
+            or machine.serialconsole.stype.name != "IPMI"
+        ):
+            logger.error(
+                "SOL deactivate skipped for non-IPMI machine: %s", machine.fqdn
+            )
+            return
+
+        if not machine.has_bmc():
+            logger.error(
+                "SOL deactivate skipped because machine has no BMC: %s", machine.fqdn
+            )
+            return
+
+        cscreen_server = machine.fqdn_domain.cscreen_server
+        if not cscreen_server:
+            logger.error(
+                "SOL deactivate skipped because no cscreen server is configured: %s",
+                machine.fqdn,
+            )
+            return
+
+        host = (machine.bmc.fqdn or "").strip()
+        username = (
+            machine.bmc.username
+            or ServerConfig.get_server_config_manager().by_key(
+                "serialconsole.ipmi.username", ""
+            )
+            or ""
+        ).strip()
+        password = (
+            machine.bmc.password
+            or ServerConfig.get_server_config_manager().by_key(
+                "serialconsole.ipmi.password", ""
+            )
+            or ""
+        )
+
+        if not host:
+            logger.error(
+                "SOL deactivate skipped because BMC host is empty: %s", machine.fqdn
+            )
+            return
+
+        if not username:
+            logger.error(
+                "SOL deactivate skipped because IPMI username is empty: %s",
+                machine.fqdn,
+            )
+            return
+
+        if any(char in host for char in ("\x00", "\r", "\n")):
+            logger.error(
+                "SOL deactivate skipped because BMC host is invalid: %s", machine.fqdn
+            )
+            return
+
+        host_is_hostname = re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9.-]*", host) is not None
+        host_is_ip = False
+        try:
+            ipaddress.ip_address(host)
+            host_is_ip = True
+        except ValueError:
+            pass
+
+        if not (host_is_hostname or host_is_ip):
+            logger.error(
+                "SOL deactivate skipped because BMC host is invalid: %s", machine.fqdn
+            )
+            return
+
+        if re.fullmatch(r"[A-Za-z0-9_.@-]+", username) is None:
+            logger.error(
+                "SOL deactivate skipped because IPMI username is invalid: %s",
+                machine.fqdn,
+            )
+            return
+
+        if "\x00" in password:
+            logger.error(
+                "SOL deactivate skipped because IPMI password contains null byte: %s",
+                machine.fqdn,
+            )
+            return
+
+        command = "/usr/bin/ipmitool -I lanplus -H {} -U {} -E sol deactivate".format(
+            shlex.quote(host),
+            shlex.quote(username),
+        )
+
+        conn = None
+        try:
+            conn = SSH(cscreen_server.fqdn)
+            conn.connect(user="_cscreen")
+            _stdout, stderr, exitstatus = conn.execute(
+                command,
+                retry=False,
+                timeout=timeout_seconds,
+                environment={"IPMI_PASSWORD": password},
+            )
+            if exitstatus != 0:
+                logger.error(
+                    "SOL deactivate failed for %s via %s: %s",
+                    machine.fqdn,
+                    cscreen_server.fqdn,
+                    "".join(stderr).strip(),
+                )
+                return
+            logger.info(
+                "SOL deactivate finished for %s via %s",
+                machine.fqdn,
+                cscreen_server.fqdn,
+            )
+        except SSH.Exception as exception:
+            logger.exception(exception)
+        finally:
+            if conn:
+                conn.close()

--- a/orthos2/taskmanager/tests.py
+++ b/orthos2/taskmanager/tests.py
@@ -1,1 +1,56 @@
-# Create your tests here.
+from unittest import mock
+
+from django.test import TestCase
+
+from orthos2.data.models import Machine
+from orthos2.taskmanager.tasks.sol import DeactivateSerialOverLan
+
+
+class DeactivateSerialOverLanTaskTest(TestCase):
+    fixtures = ["orthos2/utils/tests/fixtures/machines.json"]
+
+    @mock.patch("orthos2.taskmanager.tasks.sol.SSH")
+    def test_execute_runs_ipmitool_via_cscreen_server(
+        self, mocked_ssh: mock.MagicMock
+    ) -> None:
+        """Task should execute SOL deactivation over SSH on the cscreen server."""
+
+        machine = Machine.objects.get(pk=2)
+        machine.fqdn_domain.__class__.objects.filter(pk=machine.fqdn_domain.pk).update(
+            cscreen_server=machine
+        )
+
+        mocked_conn = mocked_ssh.return_value
+        mocked_conn.execute.return_value = (["ok"], [], 0)
+
+        task = DeactivateSerialOverLan(machine.pk)
+        task.execute()
+
+        mocked_ssh.assert_called_once_with(machine.fqdn)
+        mocked_conn.connect.assert_called_once_with(user="_cscreen")
+        mocked_conn.execute.assert_called_once()
+
+        called_args = mocked_conn.execute.call_args.args
+        called_kwargs = mocked_conn.execute.call_args.kwargs
+
+        self.assertIn("/usr/bin/ipmitool", called_args[0])
+        self.assertIn("-E", called_args[0])
+        self.assertEqual(called_kwargs["timeout"], 30.0)
+        self.assertEqual(called_kwargs["environment"]["IPMI_PASSWORD"], "root")
+        mocked_conn.close.assert_called_once()
+
+    @mock.patch("orthos2.taskmanager.tasks.sol.SSH")
+    def test_execute_skips_when_no_cscreen_server(
+        self, mocked_ssh: mock.MagicMock
+    ) -> None:
+        """Task should not attempt SSH when no serial console server is configured."""
+
+        machine = Machine.objects.get(pk=2)
+        machine.fqdn_domain.__class__.objects.filter(pk=machine.fqdn_domain.pk).update(
+            cscreen_server=None
+        )
+
+        task = DeactivateSerialOverLan(machine.pk)
+        task.execute()
+
+        mocked_ssh.assert_not_called()

--- a/orthos2/utils/ssh.py
+++ b/orthos2/utils/ssh.py
@@ -131,7 +131,11 @@ class SSH(object):
         raise SSH.Exception(last_exception)
 
     def execute(
-        self, command: str, retry: bool = True, timeout: Optional[float] = None
+        self,
+        command: str,
+        retry: bool = True,
+        timeout: Optional[float] = None,
+        environment: Optional[Dict[str, str]] = None,
     ) -> Tuple[Union[Iterable[str], TextIO], Union[Iterable[str], TextIO], int]:
         """
         Execute the given command.
@@ -139,12 +143,17 @@ class SSH(object):
         :param command: The command to execute.
         :param retry: Set to "True" to retry the command once if it failed on the remote (default).
         :param timeout: Timeout in seconds or "None" to disable setting a timeout (default).
+        :param environment: Optional environment variables for Paramiko `exec_command()`.
         :returns: A tuple containing stdout (list), stderr (list) and exit status (int).
         """
         try:
             stdout: Union[Iterable[str], TextIO]
             stderr: Union[Iterable[str], TextIO]
-            _stdin, stdout, stderr = self._client.exec_command(command, timeout=timeout)
+            _stdin, stdout, stderr = self._client.exec_command(
+                command,
+                timeout=timeout,
+                environment=environment,
+            )
             exitstatus = stdout.channel.recv_exit_status()
 
             stdout = stdout.readlines()
@@ -160,7 +169,12 @@ class SSH(object):
                 # reconnect
                 self.connect()
                 # avoid loops, therefore we set retry to False
-                return self.execute(command, retry=False)
+                return self.execute(
+                    command,
+                    retry=False,
+                    timeout=timeout,
+                    environment=environment,
+                )
             else:
                 raise SSH.Exception(str(e))
 


### PR DESCRIPTION
## What this pull request adds:
- Add Deactivate SOL button in machine actions (IPMI serial console only)
- Add AJAX endpoint for SOL deactivation
- Add machine model method to execute ipmitool sol deactivate
- Add UI and model tests for visibility, endpoint behavior, and command/error handling

A piece of  test code at orthos2/frontend/tests/admin/test_machine.py was overwritten, because it wasn't used and now contains DeactivateSolMachineTest to test this feature implementation.

### How to test:
```bash
source venv/bin/activate && ORTHOS_SECRET_KEY=test-secret-key python manage.py test orthos2.frontend.tests.admin.test_machine_views orthos2.frontend.tests.admin.test_machine -v 2
```
Please review with careful consideration, since this was partially generated by GPT-5.3-Codex

Closes #375