### PR TITLE
Allow DiskArray as embedded type

### DIFF
--- a/orthos2/data/static/js/machine_admin.js
+++ b/orthos2/data/static/js/machine_admin.js
@@ -9,7 +9,7 @@ window.addEventListener("load", function () {
                 'ppc64le': ['LPAR PowerPC', 'PowerVM', 'KVM', 'HMC', 'BareMetal'],
 
                 'aarch64': ['BareMetal', 'KVM'],
-                'embedded': ['BareMetal', 'Storage Array', 'FC Switch', 'Network Switch', 'Omni-Path Switch']
+                'embedded': ['BareMetal', 'DiskArray', 'Storage Array', 'FC Switch', 'Network Switch', 'Omni-Path Switch']
             };
 
             function filterSystems() {


### PR DESCRIPTION
Fixes #334

This adds the System "DiskArray" as an allowed type to the dynamic Django-Admin System filtering.