### PR TITLE
Add boot order warning to setup page

### DIFF
--- a/docker/orthos/fixture.json
+++ b/docker/orthos/fixture.json
@@ -1,0 +1,39 @@
+[
+  {
+    "model": "data.serverconfig",
+    "pk": null,
+    "fields": {
+      "key": "domain.validendings",
+      "value": "orthos2.test"
+    }
+  },
+  {
+    "model": "data.Domain",
+    "pk": 1,
+    "fields": {
+      "name": "orthos2.test",
+      "ip_v4": "192.0.2.0",
+      "ip_v6": "2001:db8::0",
+      "dynamic_range_v4_start": "192.0.2.50",
+      "dynamic_range_v4_end": "192.0.2.60",
+      "dynamic_range_v6_start": "2001:db8::50",
+      "dynamic_range_v6_end": "2001:db8::60"
+    }
+  },
+  {
+    "model": "data.remotepowertype",
+    "pk": null,
+    "fields": {
+      "name": "ipmilanplus",
+      "device": "bmc"
+    }
+  },
+  {
+    "model": "data.remotepowertype",
+    "pk": null,
+    "fields": {
+      "name": "eaton_ssh",
+      "device": "remotepowerdevice"
+    }
+  }
+]

--- a/docker/setup_netbox.py
+++ b/docker/setup_netbox.py
@@ -388,6 +388,7 @@ def main():
                 "extra_choices": [
                     ["redfish", "redfish"],
                     ["ipmilanplus", "ipmilanplus"],
+                    ["eaton_ssh", "eaton_ssh"],
                 ],
                 "order_alphabetically": True,
             }

--- a/orthos2/api/commands/setup.py
+++ b/orthos2/api/commands/setup.py
@@ -101,6 +101,12 @@ Example:
             result = machine.setup(distribution)
 
             if result:
+                from orthos2.utils.distribution import (
+                    is_manual_installation,
+                    is_risky_sles_version,
+                    needs_boot_order_warning,
+                )
+
                 message = "OK."
 
                 if not machine.has_remotepower():
@@ -108,6 +114,13 @@ Example:
                         " This machine has no remote power - "
                         "a manuall reboot may be required."
                     )
+
+                if needs_boot_order_warning(distribution):
+                    message += " WARNING: "
+                    if is_risky_sles_version(distribution):
+                        message += "This SLES version may require manual boot order configuration. "
+                    if is_manual_installation(distribution):
+                        message += "Manual installation requires boot order setup after OS installation. "
 
                 return Message(message).as_json
             else:

--- a/orthos2/data/models/domain.py
+++ b/orthos2/data/models/domain.py
@@ -218,11 +218,11 @@ class Domain(models.Model):
         :returns: The list of setup records from the TFTP server.
         """
 
-        if not self.tftp_server:
-            logger.warning("No TFTP server available for '%s'", self.name)
+        if not self.cobbler_server:
+            logger.warning("No Cobbler server available for '%s'", self.name)
             return {}
 
-        server = CobblerServer(self.tftp_server.fqdn_domain)
+        server = CobblerServer(self)
         records = server.get_profiles(architecture)
         logger.debug("Records:\n%s", records)
         delim_c = records[0].count(delimiter)
@@ -247,7 +247,11 @@ class Domain(models.Model):
         :returns: The list of setup records from the TFTP server grouped. They key is the distribution and the value is
                   a list of profile suffixes.
         """
-        server = CobblerServer(self.tftp_server.fqdn_domain)  # type: ignore
+        if not self.cobbler_server:
+            logger.warning("No Cobbler server available for '%s'", self.name)
+            return {}
+
+        server = CobblerServer(self)
         profiles = server.get_profiles(architecture)
 
         groups: Dict[str, List[str]] = {}

--- a/orthos2/frontend/forms/setupmachine.py
+++ b/orthos2/frontend/forms/setupmachine.py
@@ -57,7 +57,7 @@ class SetupMachineForm(forms.Form):
 
         self.fields["setup"].choices = self.get_setup_select_choices(records)  # type: ignore
         logger.debug(
-            "Setup choicen for %s.%s [%s]:\n%s\n",
+            "Setup choices for %s.%s [%s]:\n%s\n",
             machine,
             domain,
             architecture,
@@ -96,3 +96,34 @@ class SetupMachineForm(forms.Form):
         choices=[],
         widget=forms.Select(attrs={"class": "custom-select form-control"}),
     )
+
+    confirm_risky_setup = forms.BooleanField(
+        required=False,
+        initial=False,
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"}),
+        label="I understand this setup may require manual boot order configuration",
+        help_text="This distribution or installation method may leave the machine in an unbootable state.",
+    )
+
+    def clean(self) -> Optional[Dict[str, Any]]:
+        """Validate that risky setups are confirmed."""
+        from orthos2.utils.distribution import needs_boot_order_warning
+
+        cleaned_data = super().clean()
+        if cleaned_data is None:
+            return None
+        setup_choice = cleaned_data.get("setup")
+        confirmed = cleaned_data.get("confirm_risky_setup", False)
+
+        if setup_choice:
+            try:
+                if needs_boot_order_warning(setup_choice):
+                    if not confirmed:
+                        raise forms.ValidationError(
+                            "This setup choice requires manual confirmation due to potential boot order risks. "
+                            "Please check the confirmation box to proceed."
+                        )
+            except ValueError as e:
+                raise forms.ValidationError(f"Invalid setup choice format: {e}")
+
+        return cleaned_data

--- a/orthos2/frontend/forms/setupmachine.py
+++ b/orthos2/frontend/forms/setupmachine.py
@@ -3,6 +3,7 @@ This module contains all logic to set up a new machine via PXE.
 """
 
 import collections
+import json
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -55,13 +56,36 @@ class SetupMachineForm(forms.Form):
 
         super(SetupMachineForm, self).__init__(*args, **kwargs)
 
-        self.fields["setup"].choices = self.get_setup_select_choices(records)  # type: ignore
+        # Store records for JSON export to template
+        self.records = records
+
+        # Populate distro and profile fields
+        if isinstance(records, collections.OrderedDict):
+            # Build distro choices
+            distro_choices = [("", "Select a distribution...")]
+            distro_choices.extend([(distro, distro) for distro in records.keys()])
+            self.fields["distro"].choices = distro_choices  # type: ignore
+
+            # Build profile choices (all profiles from all distros for initial load)
+            profile_choices = [("", "Select a profile...")]
+            all_profiles = set()
+            for profiles in records.values():
+                all_profiles.update(profiles)
+            profile_choices.extend(
+                [(profile, profile) for profile in sorted(all_profiles)]
+            )
+            self.fields["profile"].choices = profile_choices  # type: ignore
+        else:
+            # Fallback for non-grouped records (shouldn't happen based on current code)
+            self.fields["distro"].choices = [("", "No distributions available")]  # type: ignore
+            self.fields["profile"].choices = [("", "No profiles available")]  # type: ignore
+
         logger.debug(
-            "Setup choices for %s.%s [%s]:\n%s\n",
+            "Distro choices for %s.%s [%s]:\n%s\n",
             machine,
             domain,
             architecture,
-            self.fields["setup"].choices,  # type: ignore
+            self.fields["distro"].choices,  # type: ignore
         )
 
     def get_setup_select_choices(self, records: Dict[str, List[str]]):
@@ -91,10 +115,18 @@ class SetupMachineForm(forms.Form):
 
         return setup_records
 
-    setup = forms.ChoiceField(
+    distro = forms.ChoiceField(
         required=True,
         choices=[],
         widget=forms.Select(attrs={"class": "custom-select form-control"}),
+        label="Distribution",
+    )
+
+    profile = forms.ChoiceField(
+        required=True,
+        choices=[],
+        widget=forms.Select(attrs={"class": "custom-select form-control"}),
+        label="Profile",
     )
 
     confirm_risky_setup = forms.BooleanField(
@@ -112,10 +144,15 @@ class SetupMachineForm(forms.Form):
         cleaned_data = super().clean()
         if cleaned_data is None:
             return None
-        setup_choice = cleaned_data.get("setup")
+        distro = cleaned_data.get("distro")
+        profile = cleaned_data.get("profile")
         confirmed = cleaned_data.get("confirm_risky_setup", False)
 
-        if setup_choice:
+        # Combine distro and profile into setup choice for backward compatibility
+        if distro and profile:
+            setup_choice = f"{distro}:{profile}"
+            cleaned_data["setup"] = setup_choice
+
             try:
                 if needs_boot_order_warning(setup_choice):
                     if not confirmed:
@@ -127,3 +164,7 @@ class SetupMachineForm(forms.Form):
                 raise forms.ValidationError(f"Invalid setup choice format: {e}")
 
         return cleaned_data
+
+    def get_records_json(self) -> str:
+        """Return grouped records as JSON for JavaScript."""
+        return json.dumps(self.records if hasattr(self, "records") else {})

--- a/orthos2/frontend/templates/frontend/machines/setup.html
+++ b/orthos2/frontend/templates/frontend/machines/setup.html
@@ -20,14 +20,25 @@
       <form method="post" action="{% url 'frontend:setup' machine.id %}" class="form-reservemachine">
         {% csrf_token %}
 
-        {{ form.setup.errors }}
+        {{ form.distro.errors }}
         <div class="row" style="margin: 5px;">
           <div class="col-3">
-            <label>{{ form.setup.label }}:</label>
+            <label>{{ form.distro.label }}:</label>
           </div>
           <div class="col-9">
-            {{ form.setup }}
-            <small class="form-text text-muted">{{ form.setup.help_text }}</small>
+            {{ form.distro }}
+            <small class="form-text text-muted">{{ form.distro.help_text }}</small>
+          </div>
+        </div>
+
+        {{ form.profile.errors }}
+        <div class="row" style="margin: 5px;">
+          <div class="col-3">
+            <label>{{ form.profile.label }}:</label>
+          </div>
+          <div class="col-9">
+            {{ form.profile }}
+            <small class="form-text text-muted">{{ form.profile.help_text }}</small>
           </div>
         </div>
 
@@ -53,13 +64,51 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-  const setupSelect = document.querySelector('select[name="setup"]');
+  const distroSelect = document.querySelector('select[name="distro"]');
+  const profileSelect = document.querySelector('select[name="profile"]');
   const warningDiv = document.getElementById('boot-order-warning');
   const reasonsList = document.getElementById('warning-reasons');
   const confirmCheckbox = document.querySelector('input[name="confirm_risky_setup"]');
 
+  // Grouped records passed from Django form
+  const groupedRecords = {{ form.get_records_json|safe }};
+
+  function updateProfileOptions() {
+    const selectedDistro = distroSelect.value;
+
+    // Clear current profile options
+    profileSelect.innerHTML = '<option value="">Select a profile...</option>';
+
+    if (selectedDistro && groupedRecords[selectedDistro]) {
+      // Populate profile options for selected distro
+      groupedRecords[selectedDistro].forEach(function(profile) {
+        const option = document.createElement('option');
+        option.value = profile;
+        option.textContent = profile;
+        profileSelect.appendChild(option);
+      });
+      profileSelect.disabled = false;
+    } else {
+      profileSelect.disabled = true;
+    }
+
+    // Check warnings after updating profiles
+    checkSetupChoice();
+  }
+
   function checkSetupChoice() {
-    const choice = setupSelect.value;
+    const distro = distroSelect.value;
+    const profile = profileSelect.value;
+
+    if (!distro || !profile) {
+      warningDiv.style.display = 'none';
+      confirmCheckbox.required = false;
+      confirmCheckbox.checked = false;
+      return;
+    }
+
+    // Combine distro and profile to create the choice string
+    const choice = distro + ':' + profile;
     const reasons = [];
 
     // Check for Micro versions first - all Micro versions are safe (no version warning)
@@ -93,8 +142,12 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  setupSelect.addEventListener('change', checkSetupChoice);
-  checkSetupChoice(); // Run on page load
+  // Event listeners
+  distroSelect.addEventListener('change', updateProfileOptions);
+  profileSelect.addEventListener('change', checkSetupChoice);
+
+  // Initialize on page load
+  updateProfileOptions();
 });
 </script>
 {% endblock %}

--- a/orthos2/frontend/templates/frontend/machines/setup.html
+++ b/orthos2/frontend/templates/frontend/machines/setup.html
@@ -29,10 +29,72 @@
             {{ form.setup }}
             <small class="form-text text-muted">{{ form.setup.help_text }}</small>
           </div>
+        </div>
+
+        <div id="boot-order-warning" class="alert alert-warning" style="display: none; margin: 15px 0;">
+          <strong>Warning: Boot Order Risk</strong>
+          <p>This setup choice may require manual BIOS/UEFI configuration:</p>
+          <ul id="warning-reasons"></ul>
+          <div class="form-check">
+            {{ form.confirm_risky_setup }}
+            <label class="form-check-label" for="{{ form.confirm_risky_setup.id_for_label }}">
+              {{ form.confirm_risky_setup.label }}
+            </label>
+          </div>
+          <small class="form-text text-muted">{{ form.confirm_risky_setup.help_text }}</small>
+          {{ form.confirm_risky_setup.errors }}
+        </div>
 
         <button type="submit" class="btn btn-secondary btn-sm btn-block">Start Setup</button>
       </form>
     </div>
   </div>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const setupSelect = document.querySelector('select[name="setup"]');
+  const warningDiv = document.getElementById('boot-order-warning');
+  const reasonsList = document.getElementById('warning-reasons');
+  const confirmCheckbox = document.querySelector('input[name="confirm_risky_setup"]');
+
+  function checkSetupChoice() {
+    const choice = setupSelect.value;
+    const reasons = [];
+
+    // Check for Micro versions first - all Micro versions are safe (no version warning)
+    const isMicro = choice.match(/^SLE?-Micro-/i);
+
+    // Check for old SLES version (< 15 SP3) - only for regular SLES, not Micro
+    if (!isMicro) {
+      let slesMatch = choice.match(/^SLES?-(\d+)-SP(\d+)/i);
+      if (slesMatch) {
+        const major = parseInt(slesMatch[1]);
+        const sp = parseInt(slesMatch[2]);
+        if (major < 15 || (major === 15 && sp < 3)) {
+          reasons.push('SLES version older than 15 SP3 may have boot order issues');
+        }
+      }
+    }
+
+    // Check for manual installation (applies to both regular SLES and Micro)
+    if (choice.match(/:install$/) || choice.match(/:install-ssh$/)) {
+      reasons.push('Manual installation may change boot order');
+    }
+
+    if (reasons.length > 0) {
+      reasonsList.innerHTML = reasons.map(r => '<li>' + r + '</li>').join('');
+      warningDiv.style.display = 'block';
+      confirmCheckbox.required = true;
+    } else {
+      warningDiv.style.display = 'none';
+      confirmCheckbox.required = false;
+      confirmCheckbox.checked = false;
+    }
+  }
+
+  setupSelect.addEventListener('change', checkSetupChoice);
+  checkSetupChoice(); // Run on page load
+});
+</script>
 {% endblock %}

--- a/orthos2/frontend/views/machine.py
+++ b/orthos2/frontend/views/machine.py
@@ -358,7 +358,25 @@ def setup(
                 result = machine.setup(choice)
 
                 if result:
+                    from orthos2.utils.distribution import (
+                        is_manual_installation,
+                        is_risky_sles_version,
+                        needs_boot_order_warning,
+                    )
+
                     messages.success(request, "Setup '{}' initialized.".format(choice))
+
+                    if needs_boot_order_warning(choice):
+                        warning_msg = "Note: "
+                        if is_risky_sles_version(choice):
+                            warning_msg += "This SLES version may require manual BIOS/UEFI boot order configuration. "
+                        if is_manual_installation(choice):
+                            warning_msg += (
+                                "Manual installation requires setting boot order after OS installation "
+                                "completes."
+                            )
+
+                        messages.warning(request, warning_msg)
                 else:
                     messages.warning(
                         request,

--- a/orthos2/taskmanager/tasks/notifications.py
+++ b/orthos2/taskmanager/tasks/notifications.py
@@ -162,6 +162,7 @@ class CheckReservationExpiration(Task):
                     machine.fqdn, delta.days
                 )
 
+            # Build base message
             message = """Hi {username},
 
 The machine reservation for {fqdn} expires at {reserved_until}.
@@ -176,12 +177,51 @@ Or use the following commandline interface command:
   (orthos) RESERVE {fqdn}
 
 Please note, that the machine will be setup after reservation expired!
+"""
 
+            # Add boot order warning if autoreinstall is enabled and default profile is risky
+            from orthos2.utils.distribution import (
+                is_manual_installation,
+                is_risky_sles_version,
+                needs_boot_order_warning,
+            )
+
+            boot_warning = ""
+            if machine.autoreinstall and machine.architecture.default_profile:
+                default_profile = machine.architecture.default_profile
+                if needs_boot_order_warning(default_profile):
+                    boot_warning = """
+BOOT ORDER WARNING
+After automatic reinstallation, this machine may not boot properly.
+"""
+
+                    if is_risky_sles_version(default_profile):
+                        boot_warning += (
+                            "  - The default profile uses SLES < 15 SP3, which may have boot order "
+                            "issues.\n"
+                        )
+
+                    if is_manual_installation(default_profile):
+                        boot_warning += (
+                            "- The default profile uses manual installation, requiring boot order "
+                            "configuration.\n"
+                        )
+
+                    boot_warning += """
+You may need to manually configure the BIOS/UEFI boot order after reinstallation.
+Consider extending your reservation or disabling autoreinstall for this machine.
+"""
+
+            message += boot_warning
+
+            message += """
 If you have any problems, contact <{support_contact}>.
 
 
 Regards,
-Orthos""".format(
+Orthos"""
+
+            message = message.format(
                 username=user.username,  # type: ignore
                 fqdn=machine.fqdn,
                 reserved_until=machine.reserved_until,

--- a/orthos2/utils/distribution.py
+++ b/orthos2/utils/distribution.py
@@ -1,0 +1,183 @@
+"""
+Utility functions for distribution version parsing and risk detection.
+
+This module provides functions to parse SLES versions and detect risky
+setup choices that may affect boot order.
+"""
+
+import re
+from typing import Optional, Tuple
+
+
+def parse_sles_version(distribution: str) -> Optional[Tuple[int, int]]:
+    """
+    Parse SLES version from distribution string.
+
+    Only parses regular SLES versions (SLE-15-SP3, SLES-12-SP4).
+    SLE-Micro and SL-Micro versions are not parsed and return None.
+
+    Args:
+        distribution: Distribution name (e.g., "SLE-15-SP3-Server-LATEST:install-auto")
+
+    Returns:
+        Tuple of (major, service_pack) or None if not regular SLES or unparseable
+
+    Examples:
+        >>> parse_sles_version("SLE-15-SP3-Server-LATEST:install")
+        (15, 3)
+        >>> parse_sles_version("SLE-12-SP4-Server-LATEST")
+        (12, 4)
+        >>> parse_sles_version("SLE-Micro-5.5")
+        None
+        >>> parse_sles_version("SL-Micro-6.0")
+        None
+        >>> parse_sles_version("openSUSE-Leap-15.3")
+        None
+    """
+    # Parse regular SLES pattern: SLE-15-SP3, SLES-12-SP4
+    # Note: SLE-Micro and SL-Micro are NOT parsed here
+    pattern = re.compile(r"^SLES?-(\d+)-SP(\d+)", re.IGNORECASE)
+    match = pattern.match(distribution)
+
+    if match:
+        major = int(match.group(1))
+        service_pack = int(match.group(2))
+        return major, service_pack
+
+    return None
+
+
+def is_risky_sles_version(distribution: str) -> bool:
+    """
+    Check if SLES distribution is older than 15 SP3.
+
+    SLES versions older than 15 SP3 may have boot order issues when
+    automatic installation is performed with newer codestreams.
+    All SLE-Micro and SL-Micro versions are considered safe.
+
+    Args:
+        distribution: Distribution name with or without profile
+
+    Returns:
+        True if SLES and version < 15 SP3, False otherwise
+        (Returns False for non-SLES distributions and all Micro editions)
+
+    Examples:
+        >>> is_risky_sles_version("SLE-12-SP4-Server-LATEST")
+        True
+        >>> is_risky_sles_version("SLE-15-SP2-Server-LATEST:install")
+        True
+        >>> is_risky_sles_version("SLE-15-SP3-Server-LATEST")
+        False
+        >>> is_risky_sles_version("SLE-Micro-5.5")
+        False
+        >>> is_risky_sles_version("SL-Micro-6.0")
+        False
+        >>> is_risky_sles_version("SL-Micro-6.2")
+        False
+        >>> is_risky_sles_version("openSUSE-Leap-15.3")
+        False
+    """
+    # Check for Micro versions first - all Micro versions are safe
+    micro_pattern = re.compile(r"^SLE?-Micro-", re.IGNORECASE)
+    if micro_pattern.match(distribution):
+        return False
+
+    # Parse regular SLES version
+    version = parse_sles_version(distribution)
+
+    if version is None:
+        return False
+
+    major, sp = version
+    return (major < 15) or (major == 15 and sp < 3)
+
+
+def is_manual_installation(profile: str) -> bool:
+    """
+    Check if profile requires manual installation.
+
+    Manual installation profiles (:install, :install-ssh) can break boot
+    order as they require manual configuration after OS installation.
+
+    Args:
+        profile: Full setup choice (e.g., "SLE-15-SP2:install")
+
+    Returns:
+        True if profile ends with :install or :install-ssh, False otherwise
+        (Excludes :install-auto and :install-auto-ssh)
+
+    Raises:
+        ValueError: If the input format is malformed (empty string, empty
+                   distribution/profile parts)
+
+    Examples:
+        >>> is_manual_installation("SLE-15-SP3:install")
+        True
+        >>> is_manual_installation("SLE-12-SP4:install-ssh")
+        True
+        >>> is_manual_installation("SLE-15-SP3:install-auto")
+        False
+        >>> is_manual_installation("SLE-15-SP3:install-auto-ssh")
+        False
+        >>> is_manual_installation("SLE-15-SP3-Server-LATEST")
+        False
+    """
+    # Check for empty string
+    if not profile:
+        raise ValueError("Distribution format is incorrect: empty string")
+
+    # No colon means no profile specified (not manual installation)
+    if ":" not in profile:
+        return False
+
+    # Split and validate parts
+    parts = profile.split(":", 1)
+    distribution_part = parts[0]
+    profile_part = parts[1]
+
+    # Validate distribution and profile parts are not empty
+    if not distribution_part:
+        raise ValueError(
+            f"Distribution format is incorrect: missing distribution part in '{profile}'"
+        )
+
+    if not profile_part:
+        raise ValueError(
+            f"Distribution format is incorrect: missing profile part in '{profile}'"
+        )
+
+    return profile_part in ("install", "install-ssh")
+
+
+def needs_boot_order_warning(setup_choice: str) -> bool:
+    """
+    Check if setup choice requires boot order warning.
+
+    A warning is needed when either:
+    1. Distribution is SLES older than 15 SP3, OR
+    2. Profile requires manual installation
+
+    Args:
+        setup_choice: Full setup choice (distribution:profile format)
+
+    Returns:
+        True if risky SLES version OR manual installation profile
+
+    Raises:
+        ValueError: If the input format is malformed (propagated from
+                   is_manual_installation)
+
+    Examples:
+        >>> needs_boot_order_warning("SLE-12-SP4:install-auto")
+        True
+        >>> needs_boot_order_warning("SLE-15-SP4:install")
+        True
+        >>> needs_boot_order_warning("SLE-12-SP4:install")
+        True
+        >>> needs_boot_order_warning("SLE-15-SP4:install-auto")
+        False
+        >>> needs_boot_order_warning("openSUSE-Leap:install")
+        False
+    """
+    return is_risky_sles_version(setup_choice) or is_manual_installation(setup_choice)

--- a/orthos2/utils/tests/test_distribution.py
+++ b/orthos2/utils/tests/test_distribution.py
@@ -1,0 +1,330 @@
+"""
+Pytest test cases for distribution utility functions.
+"""
+
+import pytest
+
+from orthos2.utils.distribution import (
+    is_manual_installation,
+    is_risky_sles_version,
+    needs_boot_order_warning,
+    parse_sles_version,
+)
+
+
+class TestParseSlesVersion:
+    """Test cases for parse_sles_version function."""
+
+    @pytest.mark.parametrize(
+        "distribution,expected",
+        [
+            # Regular SLES with SP notation
+            ("SLE-15-SP3-Server-LATEST", (15, 3)),
+            ("SLE-15-SP4-Server-LATEST", (15, 4)),
+            ("SLE-15-SP5-Server-LATEST", (15, 5)),
+            ("SLE-12-SP4-Server-LATEST", (12, 4)),
+            ("SLE-12-SP5-Server-LATEST", (12, 5)),
+            ("SLE-15-SP2-Server-LATEST", (15, 2)),
+            # SLES variant (with extra 'S')
+            ("SLES-15-SP3-Server-LATEST", (15, 3)),
+            ("SLES-12-SP4-Server-LATEST", (12, 4)),
+            # With profile suffix
+            ("SLE-15-SP3-Server-LATEST:install", (15, 3)),
+            ("SLE-15-SP3-Server-LATEST:install-auto", (15, 3)),
+            ("SLE-12-SP4-Server-LATEST:install-ssh", (12, 4)),
+            ("SLES-15-SP4:install-auto-ssh", (15, 4)),
+            # Case insensitive
+            ("sle-15-sp3-server-latest", (15, 3)),
+            ("SLE-15-sp3-SERVER-LATEST", (15, 3)),
+            # SLE-Micro versions (NOT parsed, return None)
+            ("SLE-Micro-5.5", None),
+            ("SLE-Micro-5.0", None),
+            ("SLE-Micro-6.0", None),
+            ("SLE-Micro-6.2", None),
+            # SL-Micro versions (without 'E', also NOT parsed)
+            ("SL-Micro-6.0", None),
+            ("SL-Micro-6.2", None),
+            ("SL-Micro-5.5", None),
+            # Micro with profile suffix (still NOT parsed)
+            ("SLE-Micro-5.5:install", None),
+            ("SL-Micro-6.0:install-auto", None),
+            # Case insensitive for Micro (still NOT parsed)
+            ("sle-micro-5.5", None),
+            ("SLE-MICRO-6.0", None),
+            # Non-SLES distributions should return None
+            ("openSUSE-Leap-15.3", None),
+            ("openSUSE-Tumbleweed", None),
+            ("Ubuntu-20.04", None),
+            ("RHEL-8", None),
+            ("Debian-11", None),
+            ("Fedora-38", None),
+            # Edge cases
+            ("", None),
+            ("SLE-Server-LATEST", None),  # Missing version
+            ("SLE-15", None),  # Missing SP
+            ("15-SP3", None),  # Missing SLE prefix
+            ("SLE-15-3", None),  # Missing SP keyword
+        ],
+    )
+    def test_parse_sles_version(self, distribution, expected):
+        """Test parsing SLES versions from distribution strings."""
+        assert parse_sles_version(distribution) == expected
+
+
+class TestIsRiskySlesVersion:
+    """Test cases for is_risky_sles_version function."""
+
+    @pytest.mark.parametrize(
+        "distribution,expected",
+        [
+            # Risky versions (< 15 SP3)
+            ("SLE-12-SP1-Server-LATEST", True),
+            ("SLE-12-SP2-Server-LATEST", True),
+            ("SLE-12-SP3-Server-LATEST", True),
+            ("SLE-12-SP4-Server-LATEST", True),
+            ("SLE-12-SP5-Server-LATEST", True),
+            ("SLE-15-SP0-Server-LATEST", True),
+            ("SLE-15-SP1-Server-LATEST", True),
+            ("SLE-15-SP2-Server-LATEST", True),
+            ("SLES-12-SP4-Server-LATEST", True),
+            ("SLES-15-SP2-Server-LATEST", True),
+            # Risky with profile suffix
+            ("SLE-12-SP4:install-auto", True),
+            ("SLE-15-SP2:install", True),
+            # Safe versions (>= 15 SP3)
+            ("SLE-15-SP3-Server-LATEST", False),
+            ("SLE-15-SP4-Server-LATEST", False),
+            ("SLE-15-SP5-Server-LATEST", False),
+            ("SLE-15-SP6-Server-LATEST", False),
+            ("SLES-15-SP3-Server-LATEST", False),
+            ("SLES-15-SP4-Server-LATEST", False),
+            # Safe with profile suffix
+            ("SLE-15-SP3:install", False),
+            ("SLE-15-SP4:install-auto", False),
+            # Micro versions (all safe - regardless of version number)
+            ("SLE-Micro-5.0", False),
+            ("SLE-Micro-5.5", False),
+            ("SLE-Micro-6.0", False),
+            ("SLE-Micro-6.2", False),
+            ("SL-Micro-5.5", False),
+            ("SL-Micro-6.0", False),
+            ("SL-Micro-6.2", False),
+            ("SLE-Micro-5.5:install", False),
+            ("SL-Micro-6.2:install-auto", False),
+            # Non-SLES distributions (safe - no warning)
+            ("openSUSE-Leap-15.3", False),
+            ("openSUSE-Tumbleweed", False),
+            ("Ubuntu-20.04", False),
+            ("RHEL-8", False),
+            ("Debian-11", False),
+            # Edge cases
+            ("", False),
+            ("invalid-distribution", False),
+        ],
+    )
+    def test_is_risky_sles_version(self, distribution, expected):
+        """Test detection of risky SLES versions."""
+        assert is_risky_sles_version(distribution) == expected
+
+
+class TestIsManualInstallation:
+    """Test cases for is_manual_installation function."""
+
+    @pytest.mark.parametrize(
+        "profile,expected",
+        [
+            # Manual installation profiles (risky)
+            ("SLE-15-SP3:install", True),
+            ("SLE-15-SP4:install", True),
+            ("SLE-12-SP4:install", True),
+            ("SLE-15-SP3:install-ssh", True),
+            ("SLE-12-SP4:install-ssh", True),
+            ("SLES-15-SP3:install", True),
+            ("SLE-Micro-5.5:install", True),
+            ("SL-Micro-6.0:install-ssh", True),
+            # Automatic installation profiles (safe)
+            ("SLE-15-SP3:install-auto", False),
+            ("SLE-15-SP4:install-auto", False),
+            ("SLE-12-SP4:install-auto", False),
+            ("SLE-15-SP3:install-auto-ssh", False),
+            ("SLE-12-SP4:install-auto-ssh", False),
+            ("SLES-15-SP3:install-auto", False),
+            ("SLE-Micro-5.5:install-auto", False),
+            ("SL-Micro-6.0:install-auto-ssh", False),
+            # No profile suffix (safe)
+            ("SLE-15-SP3-Server-LATEST", False),
+            ("SLE-12-SP4-Server-LATEST", False),
+            ("SLES-15-SP3", False),
+            ("SLE-Micro-5.5", False),
+            # Other profiles (safe)
+            ("SLE-15-SP3:custom-profile", False),
+            ("SLE-15-SP3:rescue", False),
+            ("SLE-15-SP3:minimal", False),
+            # No colon cases (valid - no profile specified)
+            ("install", False),  # No colon, not manual installation
+            ("install-ssh", False),  # No colon, not manual installation
+            ("SLE-15-SP3-Server-LATEST", False),  # No colon, full distribution name
+            # Ensure substring matching doesn't false positive
+            ("SLE-15-SP3:my-install", False),
+            ("SLE-15-SP3:install-something", False),
+            ("SLE-15-SP3:reinstall", False),
+        ],
+    )
+    def test_is_manual_installation(self, profile, expected):
+        """Test detection of manual installation profiles."""
+        assert is_manual_installation(profile) == expected
+
+    @pytest.mark.parametrize(
+        "profile,error_msg",
+        [
+            ("", "empty string"),
+            (":install", "missing distribution part"),
+            (":", "missing profile part"),
+            ("SLE-15-SP3:", "missing profile part"),
+        ],
+    )
+    def test_is_manual_installation_raises_on_malformed_input(self, profile, error_msg):
+        """Test that malformed inputs raise ValueError."""
+        with pytest.raises(ValueError, match="Distribution format is incorrect"):
+            is_manual_installation(profile)
+
+
+class TestNeedsBootOrderWarning:
+    """Test cases for needs_boot_order_warning function."""
+
+    @pytest.mark.parametrize(
+        "setup_choice,expected,reason",
+        [
+            # Risky SLES version alone
+            ("SLE-12-SP4:install-auto", True, "old SLES version"),
+            ("SLE-15-SP2:install-auto", True, "old SLES version"),
+            ("SLE-12-SP5:install-auto-ssh", True, "old SLES version"),
+            # Manual installation alone (on safe SLES)
+            ("SLE-15-SP4:install", True, "manual installation"),
+            ("SLE-15-SP5:install-ssh", True, "manual installation"),
+            ("SLES-15-SP3:install", True, "manual installation"),
+            ("SLE-Micro-5.5:install", True, "manual installation"),
+            # Both conditions (old SLES + manual)
+            ("SLE-12-SP4:install", True, "both old SLES and manual"),
+            ("SLE-15-SP2:install-ssh", True, "both old SLES and manual"),
+            ("SLES-12-SP5:install", True, "both old SLES and manual"),
+            # Safe configurations (new SLES + automatic)
+            ("SLE-15-SP3:install-auto", False, "safe SLES + auto install"),
+            ("SLE-15-SP4:install-auto", False, "safe SLES + auto install"),
+            ("SLE-15-SP5:install-auto-ssh", False, "safe SLES + auto install"),
+            ("SLES-15-SP4:install-auto", False, "safe SLES + auto install"),
+            ("SLE-Micro-5.5:install-auto", False, "Micro + auto install"),
+            ("SL-Micro-6.0:install-auto-ssh", False, "Micro + auto install"),
+            # Safe SLES without profile
+            ("SLE-15-SP4-Server-LATEST", False, "safe SLES no profile"),
+            ("SLE-15-SP3-Server-LATEST", False, "safe SLES no profile"),
+            # Non-SLES distributions
+            ("openSUSE-Leap:install", True, "non-SLES manual"),
+            ("openSUSE-Leap:install-ssh", True, "non-SLES manual"),
+            ("Ubuntu-20.04:install", True, "non-SLES manual"),
+            ("openSUSE-Leap:install-auto", False, "non-SLES auto"),
+            # Non-SLES without profile
+            ("openSUSE-Leap-15.3", False, "non-SLES no profile"),
+            ("Ubuntu-20.04", False, "non-SLES no profile"),
+            # Valid but no warning needed
+            ("invalid-distribution", False, "invalid distribution"),
+        ],
+    )
+    def test_needs_boot_order_warning(self, setup_choice, expected, reason):
+        """Test combined warning logic with reason annotations."""
+        assert (
+            needs_boot_order_warning(setup_choice) == expected
+        ), f"Failed for: {reason}"
+
+    @pytest.mark.parametrize(
+        "setup_choice",
+        ["", ":install", ":", "SLE-15-SP3:"],
+    )
+    def test_needs_boot_order_warning_raises_on_malformed_input(self, setup_choice):
+        """Test that malformed inputs raise ValueError."""
+        with pytest.raises(ValueError, match="Distribution format is incorrect"):
+            needs_boot_order_warning(setup_choice)
+
+
+class TestEdgeCasesAndIntegration:
+    """Additional edge case and integration tests."""
+
+    def test_parse_handles_whitespace(self):
+        """Test that parsing handles distributions with extra whitespace."""
+        # This should still return None as whitespace breaks the pattern
+        assert parse_sles_version(" SLE-15-SP3") is None
+
+    def test_case_insensitive_throughout(self):
+        """Test case insensitivity across all functions."""
+        # parse_sles_version
+        assert parse_sles_version("sle-15-sp3") == (15, 3)
+        assert parse_sles_version("SLE-15-SP3") == (15, 3)
+        assert parse_sles_version("Sle-15-Sp3") == (15, 3)
+
+        # is_risky_sles_version
+        assert is_risky_sles_version("sle-12-sp4") is True
+        assert is_risky_sles_version("SLE-12-SP4") is True
+        assert is_risky_sles_version("Sle-15-Sp2") is True
+
+        # Micro versions (all return None)
+        assert parse_sles_version("sle-micro-5.5") is None
+        assert parse_sles_version("SLE-MICRO-5.5") is None
+        assert is_risky_sles_version("sle-micro-6.2") is False
+        assert is_risky_sles_version("SLE-MICRO-6.2") is False
+
+    def test_boundary_conditions(self):
+        """Test exact boundary at SLES15 SP3."""
+        # SP2 is risky
+        assert is_risky_sles_version("SLE-15-SP2") is True
+
+        # SP3 is safe
+        assert is_risky_sles_version("SLE-15-SP3") is False
+
+        # SP4 is safe
+        assert is_risky_sles_version("SLE-15-SP4") is False
+
+    def test_profile_extraction(self):
+        """Test that profile extraction works correctly."""
+        # Manual profiles
+        assert is_manual_installation("SLE-15-SP3:install") is True
+        assert is_manual_installation("SLE-15-SP3:install-ssh") is True
+
+        # Auto profiles should not trigger
+        assert is_manual_installation("SLE-15-SP3:install-auto") is False
+        assert is_manual_installation("SLE-15-SP3:install-auto-ssh") is False
+
+    def test_micro_versions_not_parsed(self):
+        """Test that Micro versions are NOT parsed (return None)."""
+        # All Micro versions return None from parse_sles_version
+        assert parse_sles_version("SLE-Micro-5.0") is None
+        assert parse_sles_version("SLE-Micro-5.5") is None
+        assert parse_sles_version("SLE-Micro-6.0") is None
+        assert parse_sles_version("SLE-Micro-6.2") is None
+        assert parse_sles_version("SL-Micro-6.0") is None
+        assert parse_sles_version("SL-Micro-6.2") is None
+
+        # But all Micro versions are still safe (no version warning)
+        assert is_risky_sles_version("SLE-Micro-5.0") is False
+        assert is_risky_sles_version("SLE-Micro-6.2") is False
+        assert is_risky_sles_version("SL-Micro-6.0") is False
+        assert is_risky_sles_version("SL-Micro-6.2") is False
+
+    def test_warning_combinations(self):
+        """Test various combinations that should trigger warnings."""
+        # Old SLES + auto install = warning
+        assert needs_boot_order_warning("SLE-12-SP4:install-auto") is True
+
+        # New SLES + manual install = warning
+        assert needs_boot_order_warning("SLE-15-SP4:install") is True
+
+        # Old SLES + manual install = warning (both conditions)
+        assert needs_boot_order_warning("SLE-12-SP4:install") is True
+
+        # New SLES + auto install = no warning
+        assert needs_boot_order_warning("SLE-15-SP4:install-auto") is False
+
+        # Micro + manual = warning (manual always warns on SLES)
+        assert needs_boot_order_warning("SLE-Micro-5.5:install") is True
+
+        # Micro + auto = no warning
+        assert needs_boot_order_warning("SLE-Micro-5.5:install-auto") is False


### PR DESCRIPTION
Fixes #371 

This PR does the following things:

- Add a JSON fixture that can be loaded after container startup to make explorative testing easier.
- Add a warning to the setup page that is shown in case the boot order may be changed.
- Split the distro and profile select fields to improve the UX.

Boot Warning:

<img width="618" height="373" alt="image" src="https://github.com/user-attachments/assets/6922063c-5ee8-48c0-a846-57fc953f349f" />


Distro and Profile fields:

<img width="596" height="157" alt="image" src="https://github.com/user-attachments/assets/8f6ac6f3-99b2-405b-bd45-a76fa8112aea" />
