### PR TITLE
Fix RPM packaging

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,6 +1,8 @@
 workflow:
   steps:
     - branch_package:
-        source_project: systemsmanagement:orthos2:github_master_ci
-        source_package: orthos2-master
-        target_project: home:trenn
+        source_project: systemsmanagement:orthos2:master
+        source_package: orthos2
+        target_project: systemsmanagement:orthos2:github_master_ci
+  filters:
+    event: pull_request

--- a/docker/develop-leap156.dockerfile
+++ b/docker/develop-leap156.dockerfile
@@ -47,10 +47,10 @@ RUN groupadd -r orthos
 RUN useradd -r -g orthos -d /var/lib/orthos2 -s /bin/bash -c "orthos account" orthos
 
 # Create required directories
-RUN mkdir -p /etc/nginx/conf.d /var/lib/orthos2 /var/log/orthos2 /var/lib/orthos2/database /usr/lib/orthos2/ansible /run/orthos2/ansible /run/orthos2/ansible_lastrun /run/orthos2/ansible_archive
+RUN mkdir -p /etc/nginx/conf.d /var/lib/orthos2 /var/log/orthos2 /var/lib/orthos2/database /usr/lib/orthos2/ansible
 RUN touch /var/log/orthos2/default.log
 RUN chmod o+w /var/log/orthos2/default.log
-RUN chown -R orthos:orthos /var/log/orthos2 /var/lib/orthos2 /usr/lib/orthos2 /usr/lib/orthos2/ansible /run/orthos2 /run/orthos2/ansible /run/orthos2/ansible_lastrun /run/orthos2/ansible_archive
+RUN chown -R orthos:orthos /var/log/orthos2 /var/lib/orthos2 /usr/lib/orthos2 /usr/lib/orthos2/ansible
 COPY docker/traefik/certs/authentik.orthos2.test.crt /etc/pki/trust/anchors/
 RUN update-ca-certificates -v -f
 

--- a/docker/develop-tw.dockerfile
+++ b/docker/develop-tw.dockerfile
@@ -51,10 +51,10 @@ RUN groupadd -r orthos
 RUN useradd -r -u $USER -g orthos -d /var/lib/orthos2 -s /bin/bash -c "orthos account" orthos
 
 # Create required directories
-RUN mkdir -p /etc/nginx/conf.d /var/lib/orthos2 /var/log/orthos2 /var/lib/orthos2/database /usr/lib/orthos2/ansible /run/orthos2/ansible /run/orthos2/ansible_lastrun /run/orthos2/ansible_archive
+RUN mkdir -p /etc/nginx/conf.d /var/lib/orthos2 /var/log/orthos2 /var/lib/orthos2/database /usr/lib/orthos2/ansible
 RUN touch /var/log/orthos2/default.log
 RUN chmod o+w /var/log/orthos2/default.log
-RUN chown -R orthos:orthos /var/log/orthos2 /var/lib/orthos2 /usr/lib/orthos2 /usr/lib/orthos2/ansible /run/orthos2 /run/orthos2/ansible /run/orthos2/ansible_lastrun /run/orthos2/ansible_archive
+RUN chown -R orthos:orthos /var/log/orthos2 /var/lib/orthos2 /usr/lib/orthos2 /usr/lib/orthos2/ansible
 COPY docker/traefik/certs/authentik.orthos2.test.crt /etc/pki/trust/anchors/
 RUN update-ca-certificates -v -f
 

--- a/orthos2.rpmlintrc
+++ b/orthos2.rpmlintrc
@@ -2,12 +2,36 @@
 addFilter("orthos2.noarch: W: files-duplicate /usr/lib/python3.*/site-packages/orthos2")
 
 # Ansible scripts are executed remotely
+addFilter("orthos2.noarch: W: non-executable-script /usr/lib/orthos2/ansible/roles/add_custom_facts/files/facts.d/")
 addFilter("orthos2.noarch: E: non-executable-script /usr/lib/orthos2/ansible/roles/add_custom_facts/files/facts.d/")
-# django scripts are executed via manage python script
-addFilter("orthos2.noarch: E: non-executable-script /usr/lib/python3.8/site-packages/orthos2/data/scripts/")
+# Scripts that are sourced by other scripts
+addFilter("orthos2.noarch: E: non-executable-script /usr/lib/python3.*/site-packages/orthos2/data/scripts/")
+# Scripts copied by Orthos 2, to target machines
+addFilter("orthos2.noarch: W: non-executable-script /usr/lib/orthos2/scripts/")
+addFilter("orthos2.noarch: E: non-executable-script /usr/lib/orthos2/scripts/")
 
 # Need until we may get an official orthos2 user/group
 addFilter("orthos2.noarch: W: non-standard-uid *")
 addFilter("orthos2.noarch: W: non-standard-gid *")
 
 addFilter("orthos2.noarch: W: hidden-file-or-dir /var/lib/orthos2/.ssh")
+
+# False positive
+addFilter("orthos2.noarch: W: explicit-lib-dependency python3")
+addFilter("orthos2.noarch: E: explicit-lib-dependency python3")
+
+# Internal discussions for packaging /var vs. using systemd-tmpfiles
+addFilter("orthos2.noarch: E: logrotate-log-dir-not-packaged /var/log/orthos2")
+addFilter("orthos2.noarch: W: tmpfile-not-in-filelist")
+
+# %check section is executed on GitHub and too complicated for OBS
+addFilter("orthos2.spec: W: no-%check-section")
+
+# Ingore warning about indirect require for PostgreSQL client
+addFilter("orthos2.noarch: W: python-leftover-require python3-psycopg2")
+
+# Ignore non-standard group for custom user
+addFilter("system-user-orthos.noarch: W: non-standard-group System")
+
+# Ignore missing rclinks
+addFilter("orthos2.noarch: W: suse-missing-rclink")

--- a/orthos2.spec
+++ b/orthos2.spec
@@ -62,7 +62,6 @@ Requires:  %{python3_pkgversion}-requests
 Requires:  %{python3_pkgversion}-urllib3
 Requires:  %{python3_pkgversion}-paramiko
 Requires:  %{python3_pkgversion}-psycopg2
-Requires:  %{python3_pkgversion}-ldap
 Requires:  %{python3_pkgversion}-social-auth-app-django
 Requires:  %{python3_pkgversion}-social-auth-core
 Requires:  %{python3_pkgversion}-validators

--- a/orthos2.spec
+++ b/orthos2.spec
@@ -161,13 +161,12 @@ cp -r docs/_build/html/* %{buildroot}%{orthos_web_docs}
 %config(noreplace) %{_sysconfdir}/nginx/conf.d/orthos2_nginx.conf
 %dir %{_prefix}/lib/%{name}
 %dir %{_prefix}/lib/%{name}/scripts
-%{_prefix}/lib/%{name}/*
+%{_prefix}/lib/%{name}/scripts/README
+%{_prefix}/lib/%{name}/scripts/*.sh
+%{_prefix}/lib/%{name}/scripts/server_1011_power.pl
+%{_prefix}/lib/%{name}/scripts/virt-create-rootfs-orthos
 %attr(755,orthos,orthos) %{_bindir}/orthos-admin
 %attr(755,orthos,orthos) %dir /srv/www/%{name}
-%ghost %dir %{_rundir}/%{name}
-%ghost %dir %{_rundir}/%{name}/ansible
-%ghost %dir %{_rundir}/%{name}/ansible_lastrun
-%ghost %dir %{_rundir}/%{name}/ansible_archive
 %attr(755,orthos,orthos) %dir %{_localstatedir}/log/%{name}
 %attr(775,orthos,orthos) %dir %{_sharedstatedir}/%{name}
 %attr(775,orthos,orthos) %dir %{_sharedstatedir}/%{name}/archiv

--- a/orthos2.spec
+++ b/orthos2.spec
@@ -13,7 +13,7 @@
 
 %{?sle15_python_module_pythons}
 
-%if 0%{?suse_version} > 1600
+%if 0%{?suse_version} >= 1600
 %define pythons python3
 %define python3_pkgversion python3
 %else
@@ -40,13 +40,18 @@ BuildRequires:  fdupes
 BuildRequires:  systemd-rpm-macros
 # For /etc/nginx{,/conf.d} creation
 BuildRequires:  nginx
-BuildRequires:  %{python_module devel}
-BuildRequires:  %{python_module setuptools}
-# Required for python3-asgiref
-BuildRequires:  %{python_module typing_extensions if %python-base < 3.8}
-Requires(post): sudo
 BuildRequires:  python-rpm-macros
 BuildRequires:  sysuser-tools
+BuildRequires:  %{python_module devel}
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module django >= 4.2}
+BuildRequires:  %{python_module django-extensions}
+BuildRequires:  %{python_module social-auth-app-django}
+BuildRequires:  %{python_module social-auth-core}
+BuildRequires:  %{python_module paramiko}
+BuildRequires:  %{python_module djangorestframework}
+BuildRequires:  %{python_module validators}
+BuildRequires:  %{python_module netaddr}
 
 Requires:  %{python3_pkgversion}-Django >= 4.2
 Requires:  %{python3_pkgversion}-django-extensions
@@ -62,11 +67,11 @@ Requires:  %{python3_pkgversion}-social-auth-app-django
 Requires:  %{python3_pkgversion}-social-auth-core
 Requires:  %{python3_pkgversion}-validators
 Requires:  %{python3_pkgversion}-gunicorn
-
 # Needed to install /etc/logrotate.d/orthos2
 Requires:  logrotate
 Requires:  nginx
 Requires:  ansible
+Requires(post): sudo
 
 Provides: orthos2-%{version}-%{release}
 
@@ -80,26 +85,6 @@ Orthos is the machine administration tool of the development network at SUSE. It
     generating the DHCP configuration (via Cobbler)
     reboot the machines remotely
     managing remote (serial) consoles
-
-%package docs
-Summary:        HTML documentation for orthos2
-BuildRequires:  %{python_module django >= 4.2}
-BuildRequires:  %{python_module django-auth-ldap}
-BuildRequires:  %{python_module django-extensions}
-BuildRequires:  %{python_module social-auth-app-django}
-BuildRequires:  %{python_module social-auth-core}
-BuildRequires:  %{python_module paramiko}
-BuildRequires:  %{python_module djangorestframework}
-BuildRequires:  %{python_module validators}
-BuildRequires:  %{python_module netaddr}
-BuildRequires:  %{python_module ldap}
-BuildRequires:  %{python_module sphinx_rtd_theme}
-BuildRequires:  %{python_module Sphinx}
-
-%define orthos_web_docs /srv/www/orthos2/docs
-
-%description docs
-HTML documentation that can be put into a web servers htdocs directory for publishing.
 
 %package -n system-user-orthos
 Summary:        Orthos user and group
@@ -115,20 +100,12 @@ Orthos user and group required by orthos2 package
 %build
 %sysusers_generate_pre system-user-orthos.conf orthos system-user-orthos.conf
 %python_build
-cd docs
-make html
-
 
 %install
 install -D -m 0644 system-user-orthos.conf %{buildroot}%{_sysusersdir}/system-user-orthos.conf
 %python_install
 
-# docs
-mkdir -p %{buildroot}%{orthos_web_docs}
 mkdir -p %{buildroot}%{_prefix}/bin
-
-cp -r docs/_build/html/* %{buildroot}%{orthos_web_docs}
-%fdupes %{buildroot}/%{orthos_web_docs}
 %python_expand %fdupes %{buildroot}/%{$python_sitelib}/orthos2/
 %python_exec manage.py setup all --buildroot=%{buildroot} --skip-chown
 
@@ -179,10 +156,6 @@ cp -r docs/_build/html/* %{buildroot}%{orthos_web_docs}
 # Always keep this at the end with defattr
 %defattr(664, orthos, orthos, 775)
 %{_prefix}/lib/%{name}/ansible
-
-%files docs
-%dir %{orthos_web_docs}
-%{orthos_web_docs}/*
 
 %files -n system-user-orthos
 %{_sysusersdir}/system-user-orthos.conf

--- a/orthos2.spec
+++ b/orthos2.spec
@@ -143,13 +143,6 @@ mkdir -p %{buildroot}%{_prefix}/bin
 %{_prefix}/lib/%{name}/scripts/server_1011_power.pl
 %{_prefix}/lib/%{name}/scripts/virt-create-rootfs-orthos
 %attr(755,orthos,orthos) %{_bindir}/orthos-admin
-%attr(755,orthos,orthos) %dir /srv/www/%{name}
-%attr(755,orthos,orthos) %dir %{_localstatedir}/log/%{name}
-%attr(775,orthos,orthos) %dir %{_sharedstatedir}/%{name}
-%attr(775,orthos,orthos) %dir %{_sharedstatedir}/%{name}/archiv
-%attr(775,orthos,orthos) %dir %{_sharedstatedir}/%{name}/orthos-vm-images
-%attr(775,orthos,orthos) %dir %{_sharedstatedir}/%{name}/database
-%attr(700,orthos,orthos) %dir %{_sharedstatedir}/%{name}/.ssh
 
 # defattr(fileattr, user, group, dirattr)
 # Add whole ansible directory with correct attr for dirs and files

--- a/orthos2/meta/data/tmpfiles.d/orthos2.conf
+++ b/orthos2/meta/data/tmpfiles.d/orthos2.conf
@@ -1,2 +1,1 @@
-d /run/orthos2 0755 orthos orthos -
-d /run/orthos2/tmp 0755 orthos orthos -
+d /var/log/orthos2 0755 orthos orthos -

--- a/orthos2/meta/data/tmpfiles.d/orthos2.conf
+++ b/orthos2/meta/data/tmpfiles.d/orthos2.conf
@@ -1,1 +1,7 @@
 d /var/log/orthos2 0755 orthos orthos -
+d /var/lib/orthos2 0755 orthos orthos -
+d /var/lib/orthos2/.ssh 0700 orthos orthos -
+d /var/lib/orthos2/archiv 0755 orthos orthos -
+d /var/lib/orthos2/database 0755 orthos orthos -
+d /var/lib/orthos2/orthos-vm-images 0755 orthos orthos -
+d /srv/www/orthos2 0755 orthos orthos -

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ social-auth-app-django
 social-auth-core
 requests
 urllib3
+gunicorn


### PR DESCRIPTION
When building Orthos 2 inside the openSUSE Build Service, `rpmlint` is unhappy with a number of things. This PR attempts to fix them.