### PR TITLE
Ansible: Fix guarding lsscsi exection

### DIFF
--- a/orthos2/meta/data/ansible/roles/add_custom_facts/files/facts.d/lsscsi.fact
+++ b/orthos2/meta/data/ansible/roles/add_custom_facts/files/facts.d/lsscsi.fact
@@ -7,7 +7,7 @@ import sys
 
 data = {"-s": {"stdout": "", "stderr": ""}}
 
-if shutil.which("dmidecode"):
+if shutil.which("lsscsi"):
     command = ["lsscsi", "-s"]
     process = subprocess.Popen(
         command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True


### PR DESCRIPTION
This is a follow-up for #395. It fixes an issue with guarding lsscsi execution.