### PR TITLE
Fix various production issues

### DIFF
--- a/orthos2/api/commands/__init__.py
+++ b/orthos2/api/commands/__init__.py
@@ -16,6 +16,7 @@ from orthos2.api.commands.add import (
 from orthos2.api.commands.delete import (
     DeleteCommand,
     DeleteMachineCommand,
+    DeleteNetworkInterfaceCommand,
     DeleteRemotePowerCommand,
     DeleteRemotePowerDeviceCommand,
     DeleteSerialConsoleCommand,
@@ -64,6 +65,7 @@ __all__ = [
     "DeleteSerialConsoleCommand",
     "DeleteRemotePowerCommand",
     "DeleteRemotePowerDeviceCommand",
+    "DeleteNetworkInterfaceCommand",
     "AddBMCCommandPost",
     "AddBMCCommandGet",
     "AddRemotePowerDeviceCommand",

--- a/orthos2/api/commands/delete.py
+++ b/orthos2/api/commands/delete.py
@@ -24,7 +24,7 @@ from orthos2.api.serializers.misc import (
     ErrorMessage,
     InputSerializer,
 )
-from orthos2.data.models import Machine, RemotePowerDevice
+from orthos2.data.models import Machine, NetworkInterface, RemotePowerDevice
 from orthos2.utils.misc import format_cli_form_errors
 
 logger = logging.getLogger("api")
@@ -414,3 +414,61 @@ class DeleteRemotePowerDeviceCommand(BaseAPIView):
                 return ErrorMessage("Something went wrong!").as_json
 
         return ErrorMessage("\n{}".format(format_cli_form_errors(form))).as_json
+
+
+class DeleteNetworkInterfaceCommand(BaseAPIView):
+    @staticmethod
+    def get_urls() -> List[URLPattern]:
+        return [
+            re_path(
+                r"^networkinterface/(?P<id>[0-9]+)$",
+                DeleteNetworkInterfaceCommand.as_view(),
+                name="networkinterface_delete",
+            ),
+        ]
+
+    def delete(
+        self, request: Request, id: int, *args: Any, **kwargs: Any
+    ) -> JsonResponse:
+        """Delete a network interface by ID."""
+        if isinstance(request.user, AnonymousUser) or not request.auth:
+            return AuthRequiredSerializer().as_json
+
+        if not request.user.is_superuser:  # type: ignore
+            return ErrorMessage(
+                "Only superusers are allowed to perform this action!"
+            ).as_json
+
+        try:
+            interface = NetworkInterface.objects.get(pk=id)
+        except NetworkInterface.DoesNotExist:
+            return ErrorMessage(
+                "Network interface with id '{}' does not exist!".format(id)
+            ).as_json
+
+        if interface.primary:
+            return ErrorMessage(
+                "The primary network interface cannot be deleted!"
+            ).as_json
+
+        try:
+            result = interface.delete()
+
+            theader = [
+                {"objects": "Deleted objects"},
+                {"count": "#"},
+            ]
+
+            response: Dict[str, Any] = {
+                "header": {"type": "TABLE", "theader": theader},
+                "data": [],
+            }
+            for key, value in result[1].items():
+                response["data"].append(  # type: ignore
+                    {"objects": key.replace("data.", ""), "count": value}
+                )
+            return JsonResponse(response)
+
+        except Exception as e:
+            logger.exception(e)
+            return ErrorMessage("Something went wrong!").as_json

--- a/orthos2/api/serializers/machine.py
+++ b/orthos2/api/serializers/machine.py
@@ -162,6 +162,7 @@ class MachineSerializer(serializers.ModelSerializer[Machine]):
             "location_room",
             "location_rack",
             "location_rack_position",
+            "autoreinstall",
         )
 
     serial_type = serializers.CharField(source="serialconsole.stype.name")

--- a/orthos2/api/tests/commands/test_delete_networkinterface.py
+++ b/orthos2/api/tests/commands/test_delete_networkinterface.py
@@ -1,0 +1,101 @@
+"""Tests for DELETE /api/networkinterface/<id>/."""
+
+import json
+
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from orthos2.data.models import NetworkInterface
+
+
+class DeleteNetworkInterfaceUnauthenticatedTest(APITestCase):
+    """Unauthenticated requests must be rejected."""
+
+    fixtures = [
+        "orthos2/utils/tests/fixtures/machines.json",
+    ]
+
+    def test_unauthenticated_returns_auth_required(self) -> None:
+        url = reverse("api:networkinterface_delete", kwargs={"id": 3})
+        response = self.client.delete(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = json.loads(response.content)
+        assert data["header"]["type"] == "AUTHREQUIRED"
+
+
+class DeleteNetworkInterfaceTest(APITestCase):
+    """Authenticated requests to DELETE /api/networkinterface/<id>/."""
+
+    fixtures = [
+        "orthos2/utils/tests/fixtures/machines.json",
+    ]
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(
+            username="superuser", email="super@test.de", password="secret"
+        )
+        self.regular_user = User.objects.create_user(
+            username="user", email="user@test.de", password="secret"
+        )
+        superuser_token, _ = Token.objects.get_or_create(user=self.superuser)
+        self.superuser_token = superuser_token.key
+        regular_token, _ = Token.objects.get_or_create(user=self.regular_user)
+        self.regular_user_token = regular_token.key
+
+    def _auth_superuser(self) -> None:
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.superuser_token)
+
+    def _auth_regular(self) -> None:
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.regular_user_token)
+
+    def test_regular_user_is_rejected(self) -> None:
+        self._auth_regular()
+        url = reverse("api:networkinterface_delete", kwargs={"id": 3})
+        response = self.client.delete(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = json.loads(response.content)
+        assert data["header"]["type"] == "MESSAGE"
+        assert "superuser" in data["data"]["message"].lower()
+
+    def test_nonexistent_id_returns_error(self) -> None:
+        self._auth_superuser()
+        url = reverse("api:networkinterface_delete", kwargs={"id": 99999})
+        response = self.client.delete(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = json.loads(response.content)
+        assert data["header"]["type"] == "MESSAGE"
+        assert "99999" in data["data"]["message"]
+
+    def test_primary_interface_cannot_be_deleted(self) -> None:
+        # NetworkInterface pk=1 is primary (machine=1)
+        self._auth_superuser()
+        url = reverse("api:networkinterface_delete", kwargs={"id": 1})
+        response = self.client.delete(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = json.loads(response.content)
+        assert data["header"]["type"] == "MESSAGE"
+        assert "primary" in data["data"]["message"].lower()
+        assert NetworkInterface.objects.filter(pk=1).exists()
+
+    def test_secondary_interface_is_deleted(self) -> None:
+        # NetworkInterface pk=3 is secondary (machine=2, primary=False)
+        self._auth_superuser()
+        url = reverse("api:networkinterface_delete", kwargs={"id": 3})
+        response = self.client.delete(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = json.loads(response.content)
+        assert data["header"]["type"] == "TABLE"
+        assert not NetworkInterface.objects.filter(pk=3).exists()
+
+    def test_delete_response_contains_deleted_count(self) -> None:
+        self._auth_superuser()
+        url = reverse("api:networkinterface_delete", kwargs={"id": 3})
+        response = self.client.delete(url)
+        data = json.loads(response.content)
+        theader = data["header"]["theader"]
+        assert any(col.get("count") is not None for col in theader)
+        total_deleted = sum(row["count"] for row in data["data"])
+        assert total_deleted >= 1

--- a/orthos2/api/urls.py
+++ b/orthos2/api/urls.py
@@ -64,3 +64,4 @@ urlpatterns += DeleteMachineCommand.get_urls()  # noqa: F405
 urlpatterns += DeleteSerialConsoleCommand.get_urls()  # noqa: F405
 urlpatterns += DeleteRemotePowerCommand.get_urls()  # noqa: F405
 urlpatterns += DeleteRemotePowerDeviceCommand.get_urls()  # noqa: F405
+urlpatterns += DeleteNetworkInterfaceCommand.get_urls()  # noqa: F405

--- a/orthos2/data/fixtures/serialconsoletypes.json
+++ b/orthos2/data/fixtures/serialconsoletypes.json
@@ -1,7 +1,7 @@
 [
   {
     "model": "data.serialconsoletype",
-    "pk": null,
+    "pk": 1,
     "fields": {
       "name": "Device",
       "command": "{{ device }} {{ baud_rate }}",
@@ -10,7 +10,7 @@
   },
   {
     "model": "data.serialconsoletype",
-    "pk": null,
+    "pk": 2,
     "fields": {
       "name": "Telnet",
       "command": "telnet {{ console_server.fqdn }} {{ port }}",
@@ -19,7 +19,7 @@
   },
   {
     "model": "data.serialconsoletype",
-    "pk": null,
+    "pk": 3,
     "fields": {
       "name": "Command",
       "command": "{{ command }}",
@@ -28,7 +28,7 @@
   },
   {
     "model": "data.serialconsoletype",
-    "pk": null,
+    "pk": 4,
     "fields": {
       "name": "IPMI",
       "command": "ipmitool -I lanplus -H {{ machine.bmc.fqdn }} -U {{ ipmi.user}} -P {{ ipmi.password }} sol activate",
@@ -37,7 +37,7 @@
   },
   {
     "model": "data.serialconsoletype",
-    "pk": null,
+    "pk": 5,
     "fields": {
       "name": "s390",
       "command": "ssh -o StrictHostKeyChecking=no {{ machine.get_s390_hostname }}@{{ console_server.fqdn }}",
@@ -46,7 +46,7 @@
   },
   {
     "model": "data.serialconsoletype",
-    "pk": null,
+    "pk": 6,
     "fields": {
       "name": "libvirt/qemu",
       "command": "virsh -c qemu+ssh://root@{{ machine.hypervisor.fqdn }}/system console {{ machine.hostname }}",
@@ -55,7 +55,7 @@
   },
   {
     "model": "data.serialconsoletype",
-    "pk": null,
+    "pk": 7,
     "fields": {
       "name": "libvirt/lxc",
       "command": "virsh -c lxc+ssh://root@{{ machine.hypervisor.fqdn }}/system console {{ machine.hostname }}",
@@ -64,7 +64,7 @@
   },
   {
     "model": "data.serialconsoletype",
-    "pk": null,
+    "pk": 8,
     "fields": {
       "name": "PowerPC HMC",
       "command": "ssh -4 -t padmin@{{ machine.hypervisor.fqdn }} rmvterm -p {{ machine.hostname }}; mkvterm -p {{ machine.hostname }}",

--- a/orthos2/data/models/ansible.py
+++ b/orthos2/data/models/ansible.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from django.db import models
 from django.utils import timezone
 
+from orthos2.data.models.system import System
 from orthos2.utils.misc import normalize_ascii
 
 if TYPE_CHECKING:
@@ -69,12 +70,26 @@ class AnsibleScanResult(models.Model):
 
         # Update CPU fields
         machine.cpu_physical = facts.get("ansible_processor_count", 1)
-        machine.cpu_cores = machine.cpu_physical * facts.get(
-            "ansible_processor_cores", 1
+        threads_per_core = facts.get("ansible_processor_threads_per_core", 1) or 1
+
+        # ansible_processor is a flat list of [index, vendor, model, index, vendor, model, ...]
+        # Counting the numeric string entries gives the actual total logical CPU count.
+        # This avoids using ansible_processor_count * ansible_processor_cores which can be
+        # inflated on some Xen configurations where both values equal the total vCPU count.
+        processors_list = facts.get("ansible_processor", [])
+        actual_logical_cpus = sum(
+            1 for x in processors_list if isinstance(x, str) and x.isdigit()
         )
-        machine.cpu_threads = machine.cpu_cores * facts.get(
-            "ansible_processor_threads_per_core", 1
-        )
+
+        if actual_logical_cpus > 0:
+            machine.cpu_threads = actual_logical_cpus
+            machine.cpu_cores = max(actual_logical_cpus // threads_per_core, 1)
+        else:
+            machine.cpu_cores = machine.cpu_physical * facts.get(
+                "ansible_processor_cores", 1
+            )
+            machine.cpu_threads = machine.cpu_cores * threads_per_core
+
         machine.cpu_speed = Decimal(
             facts.get("ansible_local", {}).get("cpuinfo", {}).get("cpuspeed", 0.0)
         )
@@ -86,13 +101,12 @@ class AnsibleScanResult(models.Model):
         )
 
         # Update CPU model
-        processors = facts.get("ansible_processor", [])
-        if processors and isinstance(processors, list):
+        if processors_list and isinstance(processors_list, list):
             # ansible_processor contains: counts, vendor names, and model strings
             # We need to skip numeric entries and vendor names to get the actual model
             vendor_names = {"GenuineIntel", "AuthenticAMD", "ARM", "AARCH64"}
 
-            for proc in processors:
+            for proc in processors_list:
                 if isinstance(proc, str) and not proc.isdigit():
                     # Skip vendor name entries
                     if proc in vendor_names:
@@ -149,7 +163,31 @@ class AnsibleScanResult(models.Model):
 
         # Update virtualization capability
         virt_role = facts.get("ansible_virtualization_role", "")
+        virt_type = facts.get("ansible_virtualization_type", "")
         machine.vm_capable = virt_role == "host"
+
+        # Correct system type when Ansible identifies this machine as a VM guest
+        # but it is currently labeled as a non-virtual system (e.g., BareMetal).
+        if virt_role == "guest" and machine.system and not machine.system.virtual:
+            virt_type_to_system_name = {
+                "xen": "VM XEN",
+                "kvm": "VM KVM",
+            }
+            system_name = virt_type_to_system_name.get(virt_type.lower())
+            if system_name:
+                try:
+                    machine.system = System.objects.get(name=system_name)
+                    logger.info(
+                        "Updated system type for '%s' to '%s' based on Ansible facts",
+                        machine.fqdn,
+                        system_name,
+                    )
+                except System.DoesNotExist:
+                    logger.warning(
+                        "System type '%s' not found, cannot correct type for VM '%s'",
+                        system_name,
+                        machine.fqdn,
+                    )
 
         # Update hardware info fields (large text dumps)
         machine.lspci = normalize_ascii(

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -1427,7 +1427,7 @@ class Machine(models.Model):
             )
             return False
 
-        if self.serialconsole.stype.name != "IPMI":
+        if not self.serialconsole.stype.has_ipmi_sol:
             logger.warning(
                 "SOL deactivate skipped for %s: serial console type is not IPMI",
                 self.fqdn,

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -809,8 +809,20 @@ class Machine(models.Model):
             device_network_interfaces = netbox_api.check_interface_no_mgmt_by_id(
                 self.netbox_id
             )
+        ignored_interface_prefixes = (
+            "veth",
+            "flannel",
+            "docker",
+            "usb",
+            "cali",
+            "tunl",
+            "lo",
+        )
         synced_mac_addresses: Set[str] = set()
         for interface in device_network_interfaces:
+            interface_name = interface.get("name", "")
+            if any(interface_name.startswith(p) for p in ignored_interface_prefixes):
+                continue
             primary_mac = interface.get("primary_mac_address")
             if primary_mac is None:
                 continue

--- a/orthos2/data/signals.py
+++ b/orthos2/data/signals.py
@@ -79,12 +79,25 @@ def machine_pre_delete(
     """Pre delete action for machine. Save deleted machine object as file for archiving.
     Also remove the machine from the cobbler Server.
     """
-    server = CobblerServer(instance.fqdn_domain)
-    if server:
+    try:
+        server = CobblerServer(instance.fqdn_domain)
         server.remove(instance)
+    except Exception:
+        logger.warning(
+            "Failed to remove machine '%s' from Cobbler, skipping.",
+            instance.fqdn,
+            exc_info=True,
+        )
 
     if instance.is_vm_managed():
-        instance.hypervisor.virtualization_api.remove(instance)  # type: ignore
+        try:
+            instance.hypervisor.virtualization_api.remove(instance)  # type: ignore
+        except Exception:
+            logger.warning(
+                "Failed to remove VM '%s' from hypervisor, skipping.",
+                instance.fqdn,
+                exc_info=True,
+            )
 
     if not ServerConfig.get_server_config_manager().bool_by_key(
         "serialization.execute"

--- a/orthos2/data/tests/test_ansible_model.py
+++ b/orthos2/data/tests/test_ansible_model.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from orthos2.data.models import AnsibleScanResult, Domain, Machine, ServerConfig
+from orthos2.data.models.system import System
 
 
 class AnsibleScanResultModelTest(TestCase):
@@ -489,3 +490,184 @@ class AnsibleScanResultModelTest(TestCase):
         # Assert
         assert "AnsibleScan" in result_str
         assert machine.fqdn in result_str or str(machine) in result_str
+
+    def test_apply_to_machine_cpu_uses_processor_list_count(self) -> None:
+        """Should use actual processor list length for cpu_threads/cpu_cores, not count*cores."""
+        # This tests the fix for issue #374: Xen guests can report ansible_processor_count and
+        # ansible_processor_cores both equal to the vCPU count, causing count*cores inflation.
+        # The ansible_processor list contains one numeric index per logical CPU, which is reliable.
+        machine = Machine.objects.first()
+        assert machine is not None
+        facts = self._get_minimal_facts()
+        # Simulate Xen misreporting: 160 "sockets" each claiming 160 cores = 25600 (wrong).
+        # The ansible_processor list has exactly 160 numeric entries (the real vCPU count).
+        facts.update(
+            {
+                "ansible_processor_count": 160,
+                "ansible_processor_cores": 160,
+                "ansible_processor_threads_per_core": 1,
+                "ansible_processor": [str(i) for i in range(160)],  # 160 logical CPUs
+            }
+        )
+
+        result = AnsibleScanResult.objects.create(
+            machine=machine, facts_raw=facts, ansible_version="2.9.27"
+        )
+        result.apply_to_machine()
+
+        machine.refresh_from_db()
+        assert machine.cpu_physical == 160
+        assert machine.cpu_cores == 160  # not 160*160=25600
+        assert machine.cpu_threads == 160
+
+    def test_apply_to_machine_cpu_processor_list_with_hyperthreading(self) -> None:
+        """Should divide logical CPUs by threads_per_core to get cpu_cores."""
+        machine = Machine.objects.first()
+        assert machine is not None
+        facts = self._get_minimal_facts()
+        # 2 sockets, 4 cores each, 2 threads = 16 logical CPUs
+        facts.update(
+            {
+                "ansible_processor_count": 2,
+                "ansible_processor_cores": 4,
+                "ansible_processor_threads_per_core": 2,
+                "ansible_processor": [str(i) for i in range(16)],
+            }
+        )
+
+        result = AnsibleScanResult.objects.create(
+            machine=machine, facts_raw=facts, ansible_version="2.9.27"
+        )
+        result.apply_to_machine()
+
+        machine.refresh_from_db()
+        assert machine.cpu_physical == 2
+        assert machine.cpu_cores == 8  # 16 logical / 2 threads = 8 cores
+        assert machine.cpu_threads == 16
+
+    def test_apply_to_machine_cpu_falls_back_without_processor_list(self) -> None:
+        """Should fall back to count*cores formula when ansible_processor list is absent."""
+        machine = Machine.objects.first()
+        assert machine is not None
+        facts = self._get_minimal_facts()
+        facts.update(
+            {
+                "ansible_processor_count": 2,
+                "ansible_processor_cores": 4,
+                "ansible_processor_threads_per_core": 2,
+                # No ansible_processor key
+            }
+        )
+
+        result = AnsibleScanResult.objects.create(
+            machine=machine, facts_raw=facts, ansible_version="2.9.27"
+        )
+        result.apply_to_machine()
+
+        machine.refresh_from_db()
+        assert machine.cpu_physical == 2
+        assert machine.cpu_cores == 8  # 2 * 4
+        assert machine.cpu_threads == 16  # 8 * 2
+
+    def test_apply_to_machine_corrects_system_type_for_xen_guest(self) -> None:
+        """Should update machine.system to VM XEN when Ansible reports xen guest role."""
+        # Create VM XEN system type (not in the base fixture)
+        System.objects.get_or_create(name="VM XEN", defaults={"virtual": True})
+
+        machine = Machine.objects.first()
+        assert machine is not None
+        assert not machine.system.virtual  # starts as BareMetal
+
+        facts = self._get_minimal_facts()
+        facts.update(
+            {
+                "ansible_virtualization_role": "guest",
+                "ansible_virtualization_type": "xen",
+            }
+        )
+
+        result = AnsibleScanResult.objects.create(
+            machine=machine, facts_raw=facts, ansible_version="2.9.27"
+        )
+        result.apply_to_machine()
+
+        machine.refresh_from_db()
+        assert machine.system.name == "VM XEN"
+        assert machine.system.virtual is True
+
+    def test_apply_to_machine_corrects_system_type_for_kvm_guest(self) -> None:
+        """Should update machine.system to VM KVM when Ansible reports kvm guest role."""
+        System.objects.get_or_create(name="VM KVM", defaults={"virtual": True})
+
+        machine = Machine.objects.first()
+        assert machine is not None
+
+        facts = self._get_minimal_facts()
+        facts.update(
+            {
+                "ansible_virtualization_role": "guest",
+                "ansible_virtualization_type": "kvm",
+            }
+        )
+
+        result = AnsibleScanResult.objects.create(
+            machine=machine, facts_raw=facts, ansible_version="2.9.27"
+        )
+        result.apply_to_machine()
+
+        machine.refresh_from_db()
+        assert machine.system.name == "VM KVM"
+
+    def test_apply_to_machine_does_not_change_system_type_for_already_virtual(
+        self,
+    ) -> None:
+        """Should not change system type when machine is already marked virtual."""
+        vm_xen_system, _ = System.objects.get_or_create(
+            name="VM XEN", defaults={"virtual": True}
+        )
+
+        machine = Machine.objects.first()
+        assert machine is not None
+        # Set machine to already-correct VM XEN type
+        machine.system = vm_xen_system
+        machine.save()
+
+        facts = self._get_minimal_facts()
+        facts.update(
+            {
+                "ansible_virtualization_role": "guest",
+                "ansible_virtualization_type": "xen",
+            }
+        )
+
+        result = AnsibleScanResult.objects.create(
+            machine=machine, facts_raw=facts, ansible_version="2.9.27"
+        )
+        result.apply_to_machine()
+
+        machine.refresh_from_db()
+        assert machine.system.name == "VM XEN"  # unchanged
+
+    def test_apply_to_machine_does_not_change_system_type_for_unknown_virt_type(
+        self,
+    ) -> None:
+        """Should not change system type when virtualization type has no known mapping."""
+        machine = Machine.objects.first()
+        assert machine is not None
+        original_system_name = machine.system.name
+
+        facts = self._get_minimal_facts()
+        facts.update(
+            {
+                "ansible_virtualization_role": "guest",
+                "ansible_virtualization_type": "vmware",  # no mapping defined
+            }
+        )
+
+        result = AnsibleScanResult.objects.create(
+            machine=machine, facts_raw=facts, ansible_version="2.9.27"
+        )
+        result.apply_to_machine()
+
+        machine.refresh_from_db()
+        assert machine.system.name == original_system_name  # unchanged

--- a/orthos2/data/tests/test_fetch_netbox_filtering.py
+++ b/orthos2/data/tests/test_fetch_netbox_filtering.py
@@ -1,0 +1,138 @@
+"""Tests for interface name filtering in Machine.fetch_netbox()."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from orthos2.data.models import NetworkInterface, ServerConfig
+from orthos2.data.models.machine import Machine
+
+
+def _make_interface(name: str, mac: str, iface_id: int) -> dict:
+    return {
+        "name": name,
+        "id": iface_id,
+        "primary_mac_address": {"mac_address": mac},
+        "type": {"label": "1000BASE-T (1GE)"},
+    }
+
+
+def _make_netbox_api_mock(interfaces: list) -> MagicMock:
+    mock = MagicMock()
+    mock.check_interface_no_mgmt_by_id.return_value = interfaces
+    mock.check_ip_by_interface_family.return_value = []
+    mock.check_interface_mgmt_by_id.return_value = []
+    return mock
+
+
+NETBOX_MACHINE_RECORD = {
+    "description": "test machine",
+    "serial": "SN-001",
+    "custom_fields": {"product_code": "PC-001"},
+}
+
+
+class FetchNetboxInterfaceFilteringTest(TestCase):
+    """Machine.fetch_netbox() must skip interfaces with ignored name prefixes."""
+
+    fixtures = [
+        "orthos2/utils/tests/fixtures/machines.json",
+    ]
+
+    def setUp(self) -> None:
+        ServerConfig.objects.update_or_create(
+            key="domain.validendings", defaults={"value": "orthos2.test"}
+        )
+        Machine.objects.filter(pk=1).update(netbox_id=42)
+        self.machine = Machine.objects.get(pk=1)
+        # machine.save() inside fetch_netbox() rejects BareMetal machines with a BMC
+        if hasattr(self.machine, "bmc"):
+            self.machine.bmc.delete()
+            self.machine = Machine.objects.get(pk=1)
+
+    def _run_fetch(self, interfaces: list) -> None:
+        mock_api = _make_netbox_api_mock(interfaces)
+        with (
+            patch(
+                "orthos2.data.models.machine.Netbox.get_instance",
+                return_value=mock_api,
+            ),
+            patch.object(
+                self.machine,
+                "fetch_netbox_record",
+                return_value=NETBOX_MACHINE_RECORD,
+            ),
+        ):
+            self.machine.fetch_netbox()
+
+    def test_veth_interface_is_ignored(self) -> None:
+        self._run_fetch([_make_interface("veth0", "00:00:00:00:00:01", 1)])
+        assert not NetworkInterface.objects.filter(
+            mac_address="00:00:00:00:00:01"
+        ).exists()
+
+    def test_flannel_interface_is_ignored(self) -> None:
+        self._run_fetch([_make_interface("flannel0", "00:00:00:00:00:02", 2)])
+        assert not NetworkInterface.objects.filter(
+            mac_address="00:00:00:00:00:02"
+        ).exists()
+
+    def test_docker_interface_is_ignored(self) -> None:
+        self._run_fetch([_make_interface("docker0", "00:00:00:00:00:03", 3)])
+        assert not NetworkInterface.objects.filter(
+            mac_address="00:00:00:00:00:03"
+        ).exists()
+
+    def test_usb_interface_is_ignored(self) -> None:
+        self._run_fetch([_make_interface("usb0", "00:00:00:00:00:04", 4)])
+        assert not NetworkInterface.objects.filter(
+            mac_address="00:00:00:00:00:04"
+        ).exists()
+
+    def test_cali_interface_is_ignored(self) -> None:
+        self._run_fetch([_make_interface("cali1234abcd", "00:00:00:00:00:05", 5)])
+        assert not NetworkInterface.objects.filter(
+            mac_address="00:00:00:00:00:05"
+        ).exists()
+
+    def test_tunl_interface_is_ignored(self) -> None:
+        self._run_fetch([_make_interface("tunl0", "00:00:00:00:00:06", 6)])
+        assert not NetworkInterface.objects.filter(
+            mac_address="00:00:00:00:00:06"
+        ).exists()
+
+    def test_lo_interface_is_ignored(self) -> None:
+        self._run_fetch([_make_interface("lo", "00:00:00:00:00:07", 7)])
+        assert not NetworkInterface.objects.filter(
+            mac_address="00:00:00:00:00:07"
+        ).exists()
+
+    def test_regular_eth_interface_is_registered(self) -> None:
+        self._run_fetch([_make_interface("eth0", "11:22:33:44:55:66", 10)])
+        assert NetworkInterface.objects.filter(mac_address="11:22:33:44:55:66").exists()
+
+    def test_bond_interface_is_registered(self) -> None:
+        self._run_fetch([_make_interface("bond0", "11:22:33:44:55:77", 11)])
+        assert NetworkInterface.objects.filter(mac_address="11:22:33:44:55:77").exists()
+
+    def test_ens_interface_is_registered(self) -> None:
+        self._run_fetch([_make_interface("ens3", "11:22:33:44:55:88", 12)])
+        assert NetworkInterface.objects.filter(mac_address="11:22:33:44:55:88").exists()
+
+    def test_ignored_and_valid_interfaces_mixed(self) -> None:
+        """Valid interfaces are created; ignored ones are not."""
+        interfaces = [
+            _make_interface("veth0", "AA:00:00:00:00:01", 20),
+            _make_interface("eth1", "AA:00:00:00:00:02", 21),
+            _make_interface("flannel0", "AA:00:00:00:00:03", 22),
+            _make_interface("ens5", "AA:00:00:00:00:04", 23),
+        ]
+        self._run_fetch(interfaces)
+        assert not NetworkInterface.objects.filter(
+            mac_address="AA:00:00:00:00:01"
+        ).exists()
+        assert NetworkInterface.objects.filter(mac_address="AA:00:00:00:00:02").exists()
+        assert not NetworkInterface.objects.filter(
+            mac_address="AA:00:00:00:00:03"
+        ).exists()
+        assert NetworkInterface.objects.filter(mac_address="AA:00:00:00:00:04").exists()

--- a/orthos2/data/tests/test_signals.py
+++ b/orthos2/data/tests/test_signals.py
@@ -1,0 +1,72 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from orthos2.data.models import Machine
+from orthos2.utils.cobbler import CobblerServer
+
+
+class MachinePreDeleteSignalTests(TestCase):
+    fixtures = ["orthos2/utils/tests/fixtures/machines.json"]
+
+    def test_delete_succeeds_when_cobbler_raises_oserror(self) -> None:
+        """
+        Deleting a machine must succeed even when Cobbler is unreachable.
+
+        The pre_delete signal handler must catch OSError (and its subclasses such
+        as ConnectionRefusedError) so that a network failure does not abort the
+        database-level deletion.
+        """
+        machine = Machine.objects.get(fqdn="testsys.orthos2.test")
+        machine_pk = machine.pk
+
+        with mock.patch.object(
+            CobblerServer,
+            "remove",
+            side_effect=OSError(101, "Network is unreachable"),
+        ):
+            machine.delete()
+
+        self.assertFalse(Machine.objects.filter(pk=machine_pk).exists())
+
+    def test_delete_succeeds_when_cobbler_not_configured(self) -> None:
+        """
+        Deleting a machine must succeed even when no Cobbler server is configured
+        for the domain (CobblerServer.__init__ raises ValueError).
+        """
+        machine = Machine.objects.get(fqdn="testsys.orthos2.test")
+        machine_pk = machine.pk
+
+        with mock.patch(
+            "orthos2.data.signals.CobblerServer",
+            side_effect=ValueError("Cobbler Server not configured"),
+        ):
+            machine.delete()
+
+        self.assertFalse(Machine.objects.filter(pk=machine_pk).exists())
+
+    def test_delete_logs_warning_when_cobbler_raises_oserror(self) -> None:
+        """
+        When Cobbler is unreachable, a warning must be logged and must include
+        the machine's FQDN.
+
+        assertLogs cannot be used here because test_cobbler.py calls
+        logging.disable(logging.CRITICAL) at module level, which silences
+        all log records globally for the entire test session.  Mocking the
+        logger directly is immune to that global flag.
+        """
+        machine = Machine.objects.get(fqdn="testsys.orthos2.test")
+
+        with mock.patch.object(
+            CobblerServer,
+            "remove",
+            side_effect=OSError(101, "Network is unreachable"),
+        ), mock.patch("orthos2.data.signals.logger") as mock_logger:
+            machine.delete()
+
+        mock_logger.warning.assert_called_once()
+        fqdn_in_args = any(
+            "testsys.orthos2.test" in str(arg)
+            for arg in mock_logger.warning.call_args.args
+        )
+        self.assertTrue(fqdn_in_args)

--- a/orthos2/frontend/templates/frontend/machines/detail/networkinterface_confirm_deletion.html
+++ b/orthos2/frontend/templates/frontend/machines/detail/networkinterface_confirm_deletion.html
@@ -1,0 +1,18 @@
+{% extends 'frontend/base.html' %}
+{% load static %}
+{% load tags %}
+{% load filters %}
+
+{% block navbar %}
+{% include 'frontend/snippet.navlinks.html' %}
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <form method="post">{% csrf_token %}
+        <p>Are you sure you want to delete network interface "{{ object.name }}" ({{ object.mac_address }}) from {{ object.machine.fqdn }}?</p>
+        {{ form }}
+        <input class="btn btn-danger btn-sm" type="submit" value="Confirm deletion">
+    </form>
+</div>
+{% endblock %}

--- a/orthos2/frontend/templates/frontend/machines/detail/networkinterfaces.html
+++ b/orthos2/frontend/templates/frontend/machines/detail/networkinterfaces.html
@@ -27,6 +27,7 @@
   </tbody>
 </table>
 
+{% if machine.bmc %}
 <div class="title">
   <h5>Management Interfaces</h5>
 </div>
@@ -45,7 +46,8 @@
         <small>(<a href="http://{{ machine.bmc.fqdn }}">http</a>|<a href="https://{{ machine.bmc.fqdn }}">https</a>)</small></td>
       <td>{{ machine.bmc.comment }}</td>
     </tr>
-   
+
   </tbody>
 </table>
+{% endif %}
 {% endblock %}

--- a/orthos2/frontend/templates/frontend/machines/detail/networkinterfaces.html
+++ b/orthos2/frontend/templates/frontend/machines/detail/networkinterfaces.html
@@ -13,6 +13,7 @@
     <th>Name</th>
     <th>Driver Module</th>
     <th>Ethernet Type</th>
+    {% if request.user.is_superuser %}<th></th>{% endif %}
   </thead>
   <tbody>
     {% for network_interface in machine.networkinterfaces.all %}
@@ -22,6 +23,15 @@
       <td>{{ network_interface.name }}</td>
       <td>{{ network_interface.driver_module }}</td>
       <td>{{ network_interface.ethernet_type }}</td>
+      {% if request.user.is_superuser %}
+      <td>
+        {% if network_interface.primary %}
+        <button class="btn btn-danger btn-sm" disabled>Delete</button>
+        {% else %}
+        <a class="btn btn-danger btn-sm" href="{% url 'frontend:delete_networkinterface' network_interface.pk %}">Delete</a>
+        {% endif %}
+      </td>
+      {% endif %}
     </tr>
     {% endfor %}
   </tbody>

--- a/orthos2/frontend/templates/frontend/machines/detail/overview.html
+++ b/orthos2/frontend/templates/frontend/machines/detail/overview.html
@@ -60,6 +60,9 @@ function deactivate_sol() {
   $.ajax({
     type: 'POST',
     url: '{% url 'frontend:ajax_deactivate_sol' machine.id %}',
+    data: {
+      csrfmiddlewaretoken: '{{ csrf_token }}'
+    },
     beforeSend: function() {
       // Avoid double-submits while the backend deactivation request is running.
       $('.deactivate-sol').addClass('disabled')

--- a/orthos2/frontend/templates/frontend/machines/detail/snippets/general.html
+++ b/orthos2/frontend/templates/frontend/machines/detail/snippets/general.html
@@ -55,6 +55,10 @@
       <td class="th">NDA Hardware</td>
       <td>{{ machine.nda|boolean_image:15|safe }}</td>
     </tr>
+    <tr>
+      <td class="th">Auto-reinstall on Release</td>
+      <td>{{ machine.autoreinstall|boolean_image:15|safe }}</td>
+    </tr>
     {% if machine.group %}
     <tr>
       <td class="th">Group</td>

--- a/orthos2/frontend/tests/admin/test_networkinterface_views.py
+++ b/orthos2/frontend/tests/admin/test_networkinterface_views.py
@@ -1,0 +1,72 @@
+"""Tests for the DeleteNetworkInterface frontend view."""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from orthos2.data.models import NetworkInterface
+
+
+class DeleteNetworkInterfaceViewTest(TestCase):
+    """Tests for the networkinterface delete confirmation view."""
+
+    fixtures = [
+        "orthos2/utils/tests/fixtures/machines.json",
+        "orthos2/frontend/tests/user/fixtures/users.json",
+    ]
+
+    def test_unauthenticated_get_redirects_to_login(self) -> None:
+        url = reverse("frontend:delete_networkinterface", kwargs={"pk": 3})
+        response = self.client.get(url)
+        assert response.status_code == 302
+        assert "login" in response.url.lower()  # type: ignore[attr-defined]
+
+    def test_regular_user_get_is_forbidden(self) -> None:
+        user = User.objects.get(username="user")
+        self.client.force_login(user)
+        url = reverse("frontend:delete_networkinterface", kwargs={"pk": 3})
+        response = self.client.get(url)
+        assert response.status_code == 403
+
+    def test_superuser_get_shows_confirmation_page(self) -> None:
+        superuser = User.objects.get(username="superuser")
+        self.client.force_login(superuser)
+        url = reverse("frontend:delete_networkinterface", kwargs={"pk": 3})
+        response = self.client.get(url)
+        assert response.status_code == 200
+
+    def test_superuser_post_deletes_secondary_interface(self) -> None:
+        # NetworkInterface pk=3 is secondary (machine=2, primary=False)
+        superuser = User.objects.get(username="superuser")
+        self.client.force_login(superuser)
+        url = reverse("frontend:delete_networkinterface", kwargs={"pk": 3})
+        response = self.client.post(url)
+        assert response.status_code == 302
+        assert not NetworkInterface.objects.filter(pk=3).exists()
+
+    def test_superuser_post_redirects_to_networkinterfaces(self) -> None:
+        superuser = User.objects.get(username="superuser")
+        self.client.force_login(superuser)
+        # NetworkInterface pk=3 belongs to machine pk=2
+        url = reverse("frontend:delete_networkinterface", kwargs={"pk": 3})
+        response = self.client.post(url)
+        assert response.status_code == 302
+        expected_url = reverse("frontend:networkinterfaces", kwargs={"id": 2})
+        assert response.url == expected_url  # type: ignore[attr-defined]
+
+    def test_superuser_post_primary_interface_is_forbidden(self) -> None:
+        # NetworkInterface pk=1 is primary
+        superuser = User.objects.get(username="superuser")
+        self.client.force_login(superuser)
+        url = reverse("frontend:delete_networkinterface", kwargs={"pk": 1})
+        response = self.client.post(url)
+        assert response.status_code == 403
+        assert NetworkInterface.objects.filter(pk=1).exists()
+
+    def test_regular_user_post_is_forbidden(self) -> None:
+        user = User.objects.get(username="user")
+        self.client.force_login(user)
+        url = reverse("frontend:delete_networkinterface", kwargs={"pk": 3})
+        response = self.client.post(url)
+        assert response.status_code == 403
+        assert NetworkInterface.objects.filter(pk=3).exists()

--- a/orthos2/frontend/urls.py
+++ b/orthos2/frontend/urls.py
@@ -111,6 +111,11 @@ urlpatterns = [
         views.networkinterfaces,
         name="networkinterfaces",
     ),
+    path(
+        "networkinterface/delete/<int:pk>/",
+        views.DeleteNetworkInterface.as_view(),
+        name="delete_networkinterface",
+    ),
     re_path(r"^machine/(?P<id>[0-9]+)/pci$", views.pci, name="pci"),
     re_path(
         r"^machine/(?P<id>[0-9]+)/installations$",

--- a/orthos2/frontend/views/__init__.py
+++ b/orthos2/frontend/views/__init__.py
@@ -28,6 +28,7 @@ from .enclosures import (
     enclosure_netboxcomparison,
 )
 from .machine import (
+    DeleteNetworkInterface,
     cobbler_cleanup,
     compare_netbox,
     cpu,
@@ -96,6 +97,7 @@ __all__ = [
     "pci",
     "cpu",
     "networkinterfaces",
+    "DeleteNetworkInterface",
     "installations",
     "usb",
     "scsi",

--- a/orthos2/frontend/views/machine.py
+++ b/orthos2/frontend/views/machine.py
@@ -3,10 +3,11 @@ All views that are related to "/machine".
 """
 
 import logging
-from typing import TYPE_CHECKING, Dict, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, Set, Union
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
 from django.http import (
     Http404,
     HttpRequest,
@@ -16,8 +17,10 @@ from django.http import (
     HttpResponseRedirect,
 )
 from django.shortcuts import redirect, render  # type: ignore
+from django.urls import reverse_lazy
+from django.views.generic import DeleteView
 
-from orthos2.data.models import Machine
+from orthos2.data.models import Machine, NetworkInterface
 from orthos2.data.models.netboxorthoscomparision import NetboxOrthosComparisionRun
 from orthos2.frontend.decorators import check_permissions
 from orthos2.frontend.forms.addmachine import AddMachineFormView
@@ -571,3 +574,28 @@ def machine_add(request: "AuthenticatedHttpRequest") -> HttpResponseBase:
         return redirect("frontend:machines")
 
     return AddMachineFormView.as_view()(request)
+
+
+class DeleteNetworkInterface(DeleteView):  # type: ignore
+    model = NetworkInterface
+    template_name = "frontend/machines/detail/networkinterface_confirm_deletion.html"
+
+    def get_success_url(self) -> str:
+        return reverse_lazy(  # type: ignore
+            "frontend:networkinterfaces", kwargs={"id": self.object.machine_id}
+        )
+
+    def dispatch(
+        self, request: HttpRequest, *args: Any, **kwargs: Any
+    ) -> HttpResponseBase:
+        if not request.user.is_authenticated:
+            return redirect("frontend:login")
+        if not request.user.is_superuser:  # type: ignore
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)
+
+    def form_valid(self, form: Any) -> HttpResponse:
+        obj = self.get_object()
+        if obj.primary:
+            raise PermissionDenied
+        return super().form_valid(form)

--- a/orthos2/frontend/views/remotepowerdevice.py
+++ b/orthos2/frontend/views/remotepowerdevice.py
@@ -118,8 +118,14 @@ class NewRemotePowerDevice(PermissionRequiredMixin, CreateView):
             )
             return super().form_invalid(form)  # type: ignore
         # Fetch IPv4 and IPv6 from Primary IPs
-        primary_ipv4_id = netbox_object.get("primary_ip4", {}).get("id", "")
-        primary_ipv6_id = netbox_object.get("primary_ip6", {}).get("id", "")
+        if netbox_object.get("primary_ip4") is not None:
+            primary_ipv4_id = netbox_object.get("primary_ip4", {}).get("id", 0)
+        else:
+            primary_ipv4_id = 0
+        if netbox_object.get("primary_ip6") is not None:
+            primary_ipv6_id = netbox_object.get("primary_ip6", {}).get("id", 0)
+        else:
+            primary_ipv6_id = 0
         if not primary_ipv4_id and not primary_ipv6_id:
             form.add_error(
                 "netbox_id",

--- a/orthos2/taskmanager/tasks/sol.py
+++ b/orthos2/taskmanager/tasks/sol.py
@@ -111,10 +111,28 @@ class DeactivateSerialOverLan(Task):
             )
             return
 
-        command = "/usr/bin/ipmitool -I lanplus -H {} -U {} -E sol deactivate".format(
-            shlex.quote(host),
-            shlex.quote(username),
+        # Inject -4 or -6 if this is present inside the ipmitool command template of the serial console
+        command_parts = ["/usr/bin/ipmitool", "-I", "lanplus"]
+        if machine.serialconsole.stype.command:
+            # We don't care about placeholders here, we just want to check for the presence of -4 or -6
+            stype_command_parts = shlex.split(machine.serialconsole.stype.command)
+            if "-4" in stype_command_parts:
+                command_parts.append("-4")
+            elif "-6" in stype_command_parts:
+                command_parts.append("-6")
+
+        command_parts.extend(
+            [
+                "-H",
+                shlex.quote(host),
+                "-U",
+                shlex.quote(username),
+                "-E",
+                "sol",
+                "deactivate",
+            ]
         )
+        command = " ".join(command_parts)
 
         conn = None
         try:

--- a/orthos2/taskmanager/tasks/sol.py
+++ b/orthos2/taskmanager/tasks/sol.py
@@ -27,7 +27,7 @@ class DeactivateSerialOverLan(Task):
 
         if (
             not machine.has_serialconsole()
-            or machine.serialconsole.stype.name != "IPMI"
+            or not machine.serialconsole.stype.has_ipmi_sol
         ):
             logger.error(
                 "SOL deactivate skipped for non-IPMI machine: %s", machine.fqdn

--- a/orthos2/utils/cobbler.py
+++ b/orthos2/utils/cobbler.py
@@ -203,8 +203,8 @@ class CobblerServer:
                 self._token = token
                 return
             raise TypeError("Cobbler server returned incorrect data for token!")
-        except xmlrpc.client.Fault as xmlrpc_fault:
-            logger.error("Error logging in!", exc_info=xmlrpc_fault)
+        except (xmlrpc.client.Fault, OSError) as e:
+            logger.error("Error logging in to Cobbler!", exc_info=e)
 
     @login_required
     def add_machine(
@@ -749,7 +749,7 @@ class CobblerServer:
         """
         try:
             self._xmlrpc_server.ping()
-        except xmlrpc.client.Fault:
+        except (xmlrpc.client.Fault, OSError):
             return False
         return True
 

--- a/orthos2/utils/tests/fixtures/machines.json
+++ b/orthos2/utils/tests/fixtures/machines.json
@@ -33,7 +33,8 @@
     "fields": {
       "name": "IPMI",
       "command": "ipmitool -I lanplus -H {{ machine.bmc.fqdn }} -U {{ ipmi.user}} -P {{ ipmi.password }} sol activate",
-      "comment": "IPMI"
+      "comment": "IPMI",
+      "has_ipmi_sol": true
     }
   },
   {


### PR DESCRIPTION
Fixes #247 #289 #292 #374 

- Bugfix to make the "IPMI SOL Deactivate" button work. This will only work if `ipmitool` can successfully connect. Otherwise, a dead (not zombie) thread will be stuck.
- Importing RemotePowerDevices can be done if they only have an IP address for a single family.
- Show the "autoreinstall" property in the API and UI.
- Delete NetworkInterfaces via API and WebUI.
- Allow deletion of Servers where the Cobbler server is offline.
- Fix CPU inflation and incorrect system type of XEN VMs.