### PR TITLE
Split Nginx config into a dedicated subpackage

### DIFF
--- a/compose.testing.yaml
+++ b/compose.testing.yaml
@@ -12,6 +12,8 @@ services:
     env_file:
       - ".env"
       - "docker/orthos/orthos2dev.env"
+    volumes:
+      - ./docker/orthos/settings:/etc/orthos2/settings:ro,z
   orthos2_taskmanager:
     image: orthos2:latest
     secrets:
@@ -21,6 +23,8 @@ services:
     env_file:
       - ".env"
       - "docker/orthos/orthos2dev.env"
+    volumes:
+      - ./docker/orthos/settings:/etc/orthos2/settings:ro,z
   orthos2_nginx:
     image: orthos2-static:latest
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,8 @@ services:
       - OIDCsecret
     env_file:
       - ".env"
+    volumes:
+      - ./docker/orthos/settings:/etc/orthos2/settings:ro,z
     cap_add:
       - NET_RAW
     healthcheck:
@@ -53,6 +55,8 @@ services:
       ORTHOS2_MODE: "taskmanager"
     env_file:
       - ".env"
+    volumes:
+      - ./docker/orthos/settings:/etc/orthos2/settings:ro,z
     cap_add:
       - NET_RAW
     depends_on:

--- a/docker/orthos/settings
+++ b/docker/orthos/settings
@@ -1,0 +1,4 @@
+# This file is source/executed by /usr/lib/python*/site-packages/orthos2/settings.py
+#
+# Add your overrides here:
+#

--- a/docker/production.dockerfile
+++ b/docker/production.dockerfile
@@ -20,11 +20,17 @@ RUN --mount=type=secret,id=SCCcredentials,target=/etc/zypp/credentials.d/SCCcred
     orthos2 \
     curl
 
+# Containers log to stdout, not to a file - replace the RPM's file-logging override with the header-only template so the
+# console handler stays the only one active. RPM/bare-metal installs are unaffected since this only rewrites the file
+# inside the image; compose.yaml/compose.testing.yaml bind-mount over the same path to let operators supply their own
+# overrides without rebuilding the image.
+COPY orthos/settings /etc/orthos2/settings
+
 COPY production-server.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 # Create required directories
-RUN mkdir -p /var/log/orthos2 /srv/www/orthos2
-RUN chown -R orthos:orthos /var/log/orthos2 /srv/www/orthos2
+RUN mkdir -p /srv/www/orthos2
+RUN chown -R orthos:orthos /srv/www/orthos2
 
 RUN orthos-admin collectstatic
 EXPOSE 8000

--- a/docs/adminguide/server_configuration.rst
+++ b/docs/adminguide/server_configuration.rst
@@ -11,6 +11,13 @@ For the settings to take effect, a restart of both Orthos 2 and the Orthos 2 Tas
 All defaults are set inside the ``settings.py`` file which is contained in the Python package.
 To override them please use the file ``/etc/orthos2/settings``. The settings files follow the Python 3 syntax.
 
+In the Docker-based deployment (``compose.yaml``/``compose.testing.yaml``), ``/etc/orthos2/settings``
+is bind-mounted from ``docker/orthos/settings`` into the ``orthos2`` and ``orthos2_taskmanager``
+containers. Edit that host file and restart the containers to apply overrides - no image rebuild is
+required. Note that the production image disables the file logging handler by default (logs go to
+stdout only, for the container runtime to collect); this differs from RPM/bare-metal installs, which
+still log to ``/var/log/orthos2/default.log`` by default.
+
 NETBOX_URL
 ==========
 

--- a/docs/adminguide/setup.rst
+++ b/docs/adminguide/setup.rst
@@ -5,10 +5,11 @@ Installation/Setup (Production system)
 Install the main server
 #######################
 
-1. Install the orthos2 package:
+1. Install the orthos2 package (and, for the nginx reverse-proxy config,
+   orthos2-nginx):
     .. code-block::
 
-        $ zypper install orthos2
+        $ zypper install orthos2 orthos2-nginx
 
 2. Enter the correct server name to the nginx server conf:
     In ``/etc/nginx/conf.d/orthos2_nginx.conf`` replace ``127.0.0.1`` in the ``server_name`` directive with the fqdn of

--- a/orthos2.spec
+++ b/orthos2.spec
@@ -21,7 +21,7 @@
 %endif
 
 Name:           orthos2
-Version:        1.16
+Version:        1.17
 Release:        0
 Summary:        Machine administration
 Url:            https://github.com/openSUSE/orthos2

--- a/orthos2.spec
+++ b/orthos2.spec
@@ -38,8 +38,6 @@ BuildArch:      noarch
 
 BuildRequires:  fdupes
 BuildRequires:  systemd-rpm-macros
-# For /etc/nginx{,/conf.d} creation
-BuildRequires:  nginx
 BuildRequires:  python-rpm-macros
 BuildRequires:  sysuser-tools
 BuildRequires:  %{python_module devel}
@@ -69,7 +67,6 @@ Requires:  %{python3_pkgversion}-PyYAML
 Requires:  %{python3_pkgversion}-uritemplate
 # Needed to install /etc/logrotate.d/orthos2
 Requires:  logrotate
-Requires:  nginx
 Requires:  ansible
 Requires:  openssh-clients
 Requires:  iputils
@@ -96,6 +93,16 @@ Group:          System
 
 %description -n system-user-orthos
 Orthos user and group required by orthos2 package
+
+%package nginx
+Summary:        Nginx configuration for %{name}
+BuildRequires:  nginx
+Requires:       %{name} = %{version}
+Requires:       nginx
+Supplements:    (nginx and %{name})
+
+%description nginx
+This subpackage contains the nginx configuration file for Orthos 2.
 
 %prep
 %autosetup
@@ -138,7 +145,6 @@ mkdir -p %{buildroot}%{_prefix}/bin
 %dir %{_sysconfdir}/%{name}
 %config %{_sysconfdir}/%{name}/settings
 %config %{_sysconfdir}/logrotate.d/%{name}
-%config(noreplace) %{_sysconfdir}/nginx/conf.d/orthos2_nginx.conf
 %dir %{_prefix}/lib/%{name}
 %dir %{_prefix}/lib/%{name}/scripts
 %{_prefix}/lib/%{name}/scripts/*.sh
@@ -152,6 +158,9 @@ mkdir -p %{buildroot}%{_prefix}/bin
 
 %files -n system-user-orthos
 %{_sysusersdir}/system-user-orthos.conf
+
+%files nginx
+%config(noreplace) %{_sysconfdir}/nginx/conf.d/orthos2_nginx.conf
 
 %changelog
 * Tue Sep 15 00:26:20 UTC 2020 - Thomas Renninger <trenn@suse.de>

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -916,7 +916,7 @@ class Machine(models.Model):
                 fence_name = mgmt_interface.get("custom_fields", {}).get(
                     "fence_agent", ""
                 )
-                if fence_name == "":
+                if fence_name is None or fence_name == "":
                     logger.warning(
                         "Skipped because BMC interface has no fence name set!"
                     )
@@ -939,7 +939,14 @@ class Machine(models.Model):
                     bmc.fqdn = ipv4_addresses[0].get("dns_name")  # type: ignore
                 else:
                     bmc.fqdn = ipv6_addresses[0].get("dns_name")  # type: ignore
-                bmc.fence_agent = RemotePowerType.objects.get(name=fence_name)
+                try:
+                    bmc.fence_agent = RemotePowerType.objects.get(name=fence_name)
+                except RemotePowerType.DoesNotExist:
+                    logger.warning(
+                        'Skipped because fence agent "%s" is unknown to Orthos!',
+                        fence_name,
+                    )
+                    continue
                 bmc.mac = primary_mac.get("mac_address")
                 if ipv4_address_count > 0:
                     bmc.ip_address_v4 = str(

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def requires(filename: str = "requirements.txt"):
 if __name__ == "__main__":
     setup(
         name="orthos2",
-        version="1.12",
+        version="1.17",
         description="Machine administration server",
         long_description="""
         Orthos is the machine administration tool of the development network at SUSE.


### PR DESCRIPTION
This PR is mainly opened to ensure that the Nginx config is split into a subpackage. Furthermore, this PR allows for an easier override of the Orthos 2 settings and the removal of the file-based logs inside the container.