### PR TITLE
Fix Cobbler removal gaps

### DIFF
--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -1117,9 +1117,21 @@ class Machine(models.Model):
                         exc_info=True,
                     )
 
-                # Add the machine to the new Cobbler system
-                # TODO: check if machine is known to us, and also a cobbler server
+                # Add the machine to the new Cobbler system - unless it *is* that
+                # domain's Cobbler server: a Cobbler server has no business being
+                # registered as a managed system on itself, and syncing DHCP for it
+                # here would be equally pointless (nothing about it as a Cobbler
+                # system changed - only its own domain assignment did).
                 new_domain_id = self.fqdn_domain.pk
+                if self.fqdn_domain.cobbler_server_id == self.pk:
+                    logger.info(
+                        "Skipping Cobbler update/DHCP sync for '%s': it is the"
+                        " Cobbler server for domain '%s'.",
+                        self.fqdn,
+                        self.fqdn_domain.name,
+                    )
+                    return
+
                 from orthos2.data.signals import signal_cobbler_machine_update
 
                 signal_cobbler_machine_update.send(  # type: ignore

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -1102,9 +1102,21 @@ class Machine(models.Model):
 
             if self.fqdn_domain != self._original.fqdn_domain:
                 logger.info("Domain change for: %s", self.fqdn)
-                # TODO: add error handling (checking whether the signal went through)
-                # Not removing the machine from the original Cobbler system, because there is no easy remove signal
-                # and it's probably not even necessary
+                # Remove the machine from the original Cobbler system - it belongs to the new domain's Cobbler server.
+                from orthos2.utils.cobbler import CobblerServer
+
+                try:
+                    old_server = CobblerServer(self._original.fqdn_domain)
+                    old_server.remove_by_name(self._original.fqdn)
+                except Exception:
+                    logger.warning(
+                        "Failed to remove machine '%s' from the previous Cobbler server"
+                        " of domain '%s', skipping.",
+                        self._original.fqdn,
+                        self._original.fqdn_domain.name,
+                        exc_info=True,
+                    )
+
                 # Add the machine to the new Cobbler system
                 # TODO: check if machine is known to us, and also a cobbler server
                 new_domain_id = self.fqdn_domain.pk

--- a/orthos2/data/signals.py
+++ b/orthos2/data/signals.py
@@ -153,6 +153,24 @@ def remote_power_device_post_save(
     TaskManager.add(task)
 
 
+@receiver(pre_delete, sender=RemotePowerDevice)
+def remote_power_device_pre_delete(
+    sender: Any, instance: RemotePowerDevice, *args: Any, **kwargs: Any
+) -> None:
+    """
+    Remove the Cobbler system for a given RemotePowerDevice before it is deleted.
+    """
+    try:
+        server = CobblerServer(instance.domain)
+        server.remove_by_name(instance.fqdn)
+    except Exception:
+        logger.warning(
+            "Failed to remove remote power device '%s' from Cobbler, skipping.",
+            instance.fqdn,
+            exc_info=True,
+        )
+
+
 @receiver(post_save, sender=SerialConsole)
 def serialconsole_post_save(
     sender: Any, instance: SerialConsole, *args: Any, **kwargs: Any

--- a/orthos2/data/tests/test_signals.py
+++ b/orthos2/data/tests/test_signals.py
@@ -173,6 +173,33 @@ class MachineDomainChangeSignalTests(TestCase):
         if machine.has_bmc():
             machine.bmc.delete()
 
+    def test_domain_change_skips_signals_when_new_domain_cobbler_server_is_self(
+        self,
+    ) -> None:
+        """
+        If the machine being moved to a new domain *is* that domain's Cobbler
+        server, it must not be added to Cobbler (a Cobbler server has no business
+        managing itself as a system) and must not trigger a DHCP sync either.
+        """
+        machine = Machine.objects.get(fqdn="testsys.orthos2.test")
+        new_domain = Domain.objects.get(name="other.orthos2.test")
+        new_domain.cobbler_server = machine
+        new_domain.save()
+
+        with mock.patch(
+            "orthos2.data.signals.signal_cobbler_machine_update.send"
+        ) as mock_update_send, mock.patch(
+            "orthos2.data.signals.signal_cobbler_sync_dhcp.send"
+        ) as mock_sync_send:
+            machine.fqdn = "testsys.other.orthos2.test"
+            machine.save()
+
+        mock_update_send.assert_not_called()
+        mock_sync_send.assert_not_called()
+        self.assertTrue(
+            Machine.objects.filter(fqdn="testsys.other.orthos2.test").exists()
+        )
+
     def _switch_machine_to_new_domain(self, machine: Machine) -> None:
         """Give the old domain a configured Cobbler server, then move the machine to
         the new domain - this is what actually exercises the old-domain removal code

--- a/orthos2/data/tests/test_signals.py
+++ b/orthos2/data/tests/test_signals.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.test import TestCase
 
-from orthos2.data.models import Machine
+from orthos2.data.models import Machine, RemotePowerDevice
 from orthos2.utils.cobbler import CobblerServer
 
 
@@ -68,5 +68,70 @@ class MachinePreDeleteSignalTests(TestCase):
         fqdn_in_args = any(
             "testsys.orthos2.test" in str(arg)
             for arg in mock_logger.warning.call_args.args
+        )
+        self.assertTrue(fqdn_in_args)
+
+
+class RemotePowerDevicePreDeleteSignalTests(TestCase):
+    fixtures = ["orthos2/utils/tests/fixtures/machines.json"]
+
+    def test_delete_succeeds_when_cobbler_raises_oserror(self) -> None:
+        """
+        Deleting a remote power device must succeed even when Cobbler is unreachable.
+
+        The pre_delete signal handler must catch OSError (and its subclasses such
+        as ConnectionRefusedError) so that a network failure does not abort the
+        database-level deletion.
+        """
+        device = RemotePowerDevice.objects.get(fqdn="bmc.orthos2.test")
+        device_pk = device.pk
+
+        with mock.patch.object(
+            CobblerServer,
+            "remove_by_name",
+            side_effect=OSError(101, "Network is unreachable"),
+        ):
+            device.delete()
+
+        self.assertFalse(RemotePowerDevice.objects.filter(pk=device_pk).exists())
+
+    def test_delete_succeeds_when_cobbler_not_configured(self) -> None:
+        """
+        Deleting a remote power device must succeed even when no Cobbler server is
+        configured for the domain (CobblerServer.__init__ raises ValueError).
+        """
+        device = RemotePowerDevice.objects.get(fqdn="bmc.orthos2.test")
+        device_pk = device.pk
+
+        with mock.patch(
+            "orthos2.data.signals.CobblerServer",
+            side_effect=ValueError("Cobbler Server not configured"),
+        ):
+            device.delete()
+
+        self.assertFalse(RemotePowerDevice.objects.filter(pk=device_pk).exists())
+
+    def test_delete_logs_warning_when_cobbler_raises_oserror(self) -> None:
+        """
+        When Cobbler is unreachable, a warning must be logged and must include
+        the device's FQDN.
+
+        assertLogs cannot be used here because test_cobbler.py calls
+        logging.disable(logging.CRITICAL) at module level, which silences
+        all log records globally for the entire test session.  Mocking the
+        logger directly is immune to that global flag.
+        """
+        device = RemotePowerDevice.objects.get(fqdn="bmc.orthos2.test")
+
+        with mock.patch.object(
+            CobblerServer,
+            "remove_by_name",
+            side_effect=OSError(101, "Network is unreachable"),
+        ), mock.patch("orthos2.data.signals.logger") as mock_logger:
+            device.delete()
+
+        mock_logger.warning.assert_called_once()
+        fqdn_in_args = any(
+            "bmc.orthos2.test" in str(arg) for arg in mock_logger.warning.call_args.args
         )
         self.assertTrue(fqdn_in_args)

--- a/orthos2/data/tests/test_signals.py
+++ b/orthos2/data/tests/test_signals.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.test import TestCase
 
-from orthos2.data.models import Machine, RemotePowerDevice
+from orthos2.data.models import Domain, Machine, RemotePowerDevice, ServerConfig
 from orthos2.utils.cobbler import CobblerServer
 
 
@@ -133,5 +133,116 @@ class RemotePowerDevicePreDeleteSignalTests(TestCase):
         mock_logger.warning.assert_called_once()
         fqdn_in_args = any(
             "bmc.orthos2.test" in str(arg) for arg in mock_logger.warning.call_args.args
+        )
+        self.assertTrue(fqdn_in_args)
+
+
+class MachineDomainChangeSignalTests(TestCase):
+    """
+    Changing a machine's fqdn_domain (i.e. changing its FQDN to one ending in a
+    different, also-registered domain) must remove it from the *previous* domain's
+    Cobbler server, so a stale entry doesn't linger there indefinitely - and that
+    removal must never block the domain change itself if the old Cobbler server is
+    unreachable or misconfigured.
+    """
+
+    fixtures = ["orthos2/utils/tests/fixtures/machines.json"]
+
+    def setUp(self) -> None:
+        # This fixture (unlike orthos2/data/fixtures/tests/test_domain_orthos2test.json)
+        # ships no "domain.validendings" ServerConfig entry, but both Domain.save() and
+        # Machine.save() require one to exist before validating any FQDN/domain name.
+        ServerConfig.objects.update_or_create(
+            key="domain.validendings",
+            defaults={"value": "orthos2.test,other.orthos2.test"},
+        )
+        Domain.objects.create(
+            name="other.orthos2.test",
+            ip_v4="127.0.0.1",
+            ip_v6="::1",
+            dynamic_range_v4_start="127.0.0.1",
+            dynamic_range_v4_end="127.0.0.1",
+            dynamic_range_v6_start="::1",
+            dynamic_range_v6_end="::1",
+        )
+
+        # The fixture's "testsys.orthos2.test" has a BMC attached to a System that
+        # doesn't allow one (Machine.save() enforces this), which would otherwise
+        # block every save() below - irrelevant to what's being tested here.
+        machine = Machine.objects.get(fqdn="testsys.orthos2.test")
+        if machine.has_bmc():
+            machine.bmc.delete()
+
+    def _switch_machine_to_new_domain(self, machine: Machine) -> None:
+        """Give the old domain a configured Cobbler server, then move the machine to
+        the new domain - this is what actually exercises the old-domain removal code
+        path in Machine.save()."""
+        old_domain = machine.fqdn_domain
+        old_domain.cobbler_server = Machine.objects.get(fqdn="cobbler.orthos2.test")
+        old_domain.save()
+
+        # Re-fetch so Machine.__init__'s "_original" deep copy reflects the
+        # just-persisted old_domain.cobbler_server.
+        machine = Machine.objects.get(pk=machine.pk)
+        machine.fqdn = "testsys.other.orthos2.test"
+        machine.save()
+
+    def test_domain_change_succeeds_when_old_cobbler_raises_oserror(self) -> None:
+        """
+        Changing a machine's domain must succeed even when the *previous* Cobbler
+        server is unreachable.
+        """
+        machine = Machine.objects.get(fqdn="testsys.orthos2.test")
+
+        with mock.patch.object(
+            CobblerServer,
+            "remove_by_name",
+            side_effect=OSError(101, "Network is unreachable"),
+        ) as mock_remove_by_name:
+            self._switch_machine_to_new_domain(machine)
+
+        mock_remove_by_name.assert_called_once_with("testsys.orthos2.test")
+        self.assertTrue(
+            Machine.objects.filter(fqdn="testsys.other.orthos2.test").exists()
+        )
+
+    def test_domain_change_succeeds_when_old_cobbler_not_configured(self) -> None:
+        """
+        Changing a machine's domain must succeed even when no Cobbler server is
+        configured for the *previous* domain (CobblerServer.__init__ raises
+        ValueError).
+        """
+        # Deliberately skip configuring old_domain.cobbler_server here.
+        machine = Machine.objects.get(fqdn="testsys.orthos2.test")
+        machine.fqdn = "testsys.other.orthos2.test"
+        machine.save()
+
+        self.assertTrue(
+            Machine.objects.filter(fqdn="testsys.other.orthos2.test").exists()
+        )
+
+    def test_domain_change_logs_warning_when_old_cobbler_raises_oserror(self) -> None:
+        """
+        When the previous Cobbler server is unreachable, a warning must be logged
+        and must include the machine's (old) FQDN.
+
+        assertLogs cannot be used here because test_cobbler.py calls
+        logging.disable(logging.CRITICAL) at module level, which silences all log
+        records globally for the entire test session. Mocking the logger directly
+        is immune to that global flag.
+        """
+        machine = Machine.objects.get(fqdn="testsys.orthos2.test")
+
+        with mock.patch.object(
+            CobblerServer,
+            "remove_by_name",
+            side_effect=OSError(101, "Network is unreachable"),
+        ), mock.patch("orthos2.data.models.machine.logger") as mock_logger:
+            self._switch_machine_to_new_domain(machine)
+
+        mock_logger.warning.assert_called_once()
+        fqdn_in_args = any(
+            "testsys.orthos2.test" in str(arg)
+            for arg in mock_logger.warning.call_args.args
         )
         self.assertTrue(fqdn_in_args)


### PR DESCRIPTION
This fixes small gaps in the Cobbler System handling:

- Cobbler Systems shouldn't be added to themselves.
- Remove a machine from a previous Cobbler server on domain change.
- Remove RemotePowerDevices from Cobbler during deletion.