### PR TITLE
feat(ci): introduce commitlint enforcement for commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependabot:
+        applies-to: version-updates
+        patterns:
+          - "github/codeql-action/*"
+    commit-message:
+      prefix: "build"
+      prefix-development: "chore"
+      include: "scope"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -173,3 +173,13 @@ jobs:
       - name: Run Prettier
         run: |
           npx prettier --check *.json ./**/*.json
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Lint commit messages
+        uses: wagoid/commitlint-github-action@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/psf/black
     rev: 22.3.0
@@ -16,3 +18,11 @@ repos:
     hooks:
       - id: isort
         args: ["--filter-files"]
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    # Lints commit messages against commitlint.config.js (Conventional Commits).
+    # Also enforced in CI by the "commitlint" job in .github/workflows/lint.yml
+    rev: v9.26.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,13 @@ Docker files there, and any new `COPY` sources as siblings of the Dockerfile tha
 
 ## Important Development Notes
 
+### Tooling/CI Config Precedent
+
+- `.github/workflows/lint.yml` ("Coding Style") is the single consolidated lint workflow — add new lint/CI checks
+  as a job there rather than a new workflow file.
+- `npm view`/`npm install` can fail in sandboxed shells with `EROFS` on the npm cache; use `gh api` (e.g.
+  `gh api repos/<owner>/<repo>/releases/latest`) to check package/action versions instead.
+
 ### Taskmanager Service
 
 The taskmanager runs as a **separate process** (`ORTHOS2_MODE=taskmanager`). When modifying tasks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,38 @@ Please try to create issues for any feature that you need or issue that you enco
 
 Please be aware that this project is in maintenance mode. We still welcome contributions to stabilize this project! For more details, see: <https://github.com/openSUSE/orthos2/issues/219>
 
+## Commit messages
+
+Orthos 2 follows [Conventional Commits](https://www.conventionalcommits.org/). Every commit message must be structured as:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type       | Purpose                                                    |
+|------------|-------------------------------------------------------------|
+| `feat`     | A new feature                                                |
+| `fix`      | A bug fix                                                    |
+| `docs`     | Documentation only changes                                   |
+| `style`    | Formatting, whitespace, etc. (no code meaning change)        |
+| `refactor` | Code change that neither fixes a bug nor adds a feature      |
+| `perf`     | A code change that improves performance                      |
+| `test`     | Adding or correcting tests                                   |
+| `build`    | Changes to the build system or dependencies                  |
+| `ci`       | Changes to CI configuration/scripts                          |
+| `chore`    | Other changes that don't modify src or test files             |
+
+### Enforcement
+
+This is enforced in two places:
+
+- **Locally**, via a `pre-commit` `commit-msg` hook. If you already have `pre-commit` set up for this repo, run `pre-commit install --hook-type commit-msg` once (in addition to your existing `pre-commit install`) to start linting your commit messages before they're created.
+- **In CI**, via the `commitlint` job in the "Coding Style" workflow, which runs on every pull request.
+
 For security issues and the Code of Conduct please refer to the dedicated documents.

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,9 @@
+export default {
+    extends: ["@commitlint/config-conventional"],
+    ignores: [(message) => message.includes("dependabot[bot]")],
+    rules: {
+        "body-max-line-length": [2, "always", 120],
+        "footer-max-line-length": [2, "always", 120],
+        "header-max-length": [2, "always", 72],
+    },
+};


### PR DESCRIPTION
Adopt Conventional Commits going forward, enforced both locally via a pre-commit commit-msg hook and in CI via a new commitlint job. Also add a dependabot config to keep GitHub Actions versions current.