### PR TITLE
NetBox Manufacturer & DeviceType auto-lifecycle

### DIFF
--- a/orthos2/data/models/devicetype.py
+++ b/orthos2/data/models/devicetype.py
@@ -93,6 +93,64 @@ class DeviceType(models.Model):
         """
         return cast(DeviceTypeManager, cls.objects)
 
+    @classmethod
+    def get_or_create_from_netbox(
+        cls, netbox_device_type_id: Optional[int]
+    ) -> Optional["DeviceType"]:
+        """
+        Resolve a NetBox device-type ID to an Orthos2 `DeviceType`, creating
+        it (and its `Manufacturer`, via `Manufacturer.get_or_create_from_netbox()`,
+        if needed) the first time Orthos2 sees it. Falls back to `(name,
+        manufacturer)` and backfills `netbox_id` onto a match instead of
+        creating a duplicate, the same way `Manufacturer` does - `DeviceType`
+        has no DB-level uniqueness constraint, but a manufacturer shouldn't
+        end up with two rows for what NetBox considers the same model.
+
+        :returns: None if `netbox_device_type_id` is unset, NetBox no longer
+            has a matching device type (404), or its manufacturer can't be
+            resolved.
+        :raises HTTPError: In case any HTTP code except 200 and 404 is returned.
+        """
+        if not netbox_device_type_id:
+            return None
+
+        try:
+            return cls.objects.get(netbox_id=netbox_device_type_id)
+        except cls.DoesNotExist:
+            pass
+
+        netbox_api = Netbox.get_instance()
+        try:
+            netbox_devicetype = netbox_api.fetch_device_type(netbox_device_type_id)
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                logger.info(
+                    "Fetching DeviceType %s from NetBox failed with status 404.",
+                    netbox_device_type_id,
+                )
+                return None
+            raise e
+
+        netbox_manufacturer_id = (netbox_devicetype.get("manufacturer") or {}).get("id")
+        manufacturer = Manufacturer.get_or_create_from_netbox(netbox_manufacturer_id)
+        if manufacturer is None:
+            logger.warning(
+                "Could not resolve manufacturer for NetBox DeviceType %s, "
+                "cannot create it.",
+                netbox_device_type_id,
+            )
+            return None
+
+        device_type, created = cls.objects.get_or_create(
+            name=netbox_devicetype.get("model", ""),
+            manufacturer=manufacturer,
+            defaults={"netbox_id": netbox_device_type_id},
+        )
+        if not created and device_type.netbox_id == 0:
+            device_type.netbox_id = netbox_device_type_id
+            device_type.save()
+        return device_type
+
     def fetch_netbox_record(self) -> Optional[Dict[str, Any]]:
         """
         Fetch the record of this DeviceType object from NetBox.

--- a/orthos2/data/models/machine.py
+++ b/orthos2/data/models/machine.py
@@ -786,6 +786,15 @@ class Machine(models.Model):
         )
         if product_code is not None:
             self.product_code = product_code
+        # Device Type
+        netbox_device_type_id = (netbox_machine.get("device_type") or {}).get("id")
+        if netbox_device_type_id and (
+            self.device_type is None
+            or self.device_type.netbox_id != netbox_device_type_id
+        ):
+            self.device_type = DeviceType.get_or_create_from_netbox(
+                netbox_device_type_id
+            )
         # Verify all NetworkInterfaces are created
         if self.system.virtual:
             device_network_interfaces = netbox_api.check_vm_interface_by_id(

--- a/orthos2/data/models/manufacturer.py
+++ b/orthos2/data/models/manufacturer.py
@@ -72,6 +72,60 @@ class Manufacturer(models.Model):
         """
         return cast(ManufacturerManager, cls.objects)
 
+    @classmethod
+    def get_or_create_from_netbox(
+        cls, netbox_manufacturer_id: Optional[int]
+    ) -> Optional["Manufacturer"]:
+        """
+        Resolve a NetBox manufacturer ID to an Orthos2 `Manufacturer`,
+        creating it the first time Orthos2 sees it.
+
+        Looks up by `netbox_id` first, falling back to `name` (which is
+        unique) and backfilling `netbox_id` onto a match instead of creating
+        a duplicate - migration 0044_initial_required_data.py seeds 28
+        `Manufacturer` rows (e.g. "AMD") unlinked from NetBox.
+
+        :returns: None if `netbox_manufacturer_id` is unset, NetBox no longer
+            has a matching manufacturer (404), or its name is missing.
+        :raises HTTPError: In case any HTTP code except 200 and 404 is returned.
+        """
+        if not netbox_manufacturer_id:
+            return None
+
+        try:
+            return cls.objects.get(netbox_id=netbox_manufacturer_id)
+        except cls.DoesNotExist:
+            pass
+
+        netbox_api = Netbox.get_instance()
+        try:
+            netbox_manufacturer = netbox_api.fetch_manufacturer(netbox_manufacturer_id)
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                logger.info(
+                    "Fetching Manufacturer %s from NetBox failed with status 404.",
+                    netbox_manufacturer_id,
+                )
+                return None
+            raise e
+
+        manufacturer_name = netbox_manufacturer.get("name")
+        if not manufacturer_name:
+            logger.warning(
+                "NetBox Manufacturer %s has no name, cannot resolve it.",
+                netbox_manufacturer_id,
+            )
+            return None
+
+        manufacturer, created = cls.objects.get_or_create(
+            name=manufacturer_name,
+            defaults={"netbox_id": netbox_manufacturer_id},
+        )
+        if not created and manufacturer.netbox_id == 0:
+            manufacturer.netbox_id = netbox_manufacturer_id
+            manufacturer.save()
+        return manufacturer
+
     def fetch_netbox_record(self) -> Optional[Dict[str, Any]]:
         """
         Fetch the record of this Manufacturer object from NetBox.

--- a/orthos2/data/tests/test_devicetype_auto_discovery.py
+++ b/orthos2/data/tests/test_devicetype_auto_discovery.py
@@ -1,0 +1,188 @@
+"""Tests for DeviceType.get_or_create_from_netbox()."""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+from requests import HTTPError
+from requests.models import Response
+
+from orthos2.data.models import DeviceType, Manufacturer
+
+NETBOX_DEVICETYPE_RECORD = {
+    "id": 6,
+    "model": "EPYC ROME",
+    "slug": "epyc-rome",
+    "description": "",
+    "manufacturer": {
+        "id": 4,
+        "name": "AMD",
+        "slug": "amd",
+    },
+}
+
+NETBOX_MANUFACTURER_RECORD = {
+    "id": 4,
+    "name": "AMD",
+    "slug": "amd",
+    "description": "",
+}
+
+
+def _http_error(status_code: int) -> HTTPError:
+    response = Response()
+    response.status_code = status_code
+    return HTTPError(response=response)
+
+
+class GetOrCreateFromNetboxTest(TestCase):
+    """
+    Manufacturer resolution is delegated to
+    `Manufacturer.get_or_create_from_netbox()`, which calls NetBox via its
+    own module-level `Netbox` reference (`orthos2.data.models.manufacturer`)
+    - separate from DeviceType's (`orthos2.data.models.devicetype`). Most
+    scenarios here never reach that call at all (an existing DeviceType or
+    Manufacturer already linked by netbox_id short-circuits first), so only
+    the two "resolve something brand new" tests need to mock both.
+    """
+
+    def test_returns_none_for_falsy_id(self) -> None:
+        assert DeviceType.get_or_create_from_netbox(0) is None
+        assert DeviceType.get_or_create_from_netbox(None) is None
+
+    def test_creates_manufacturer_and_devicetype_when_neither_exists(self) -> None:
+        record = {
+            **NETBOX_DEVICETYPE_RECORD,
+            "manufacturer": {"id": 99, "name": "AcmeCorp", "slug": "acmecorp"},
+        }
+        with patch(
+            "orthos2.data.models.devicetype.Netbox"
+        ) as mocked_devicetype_netbox_cls, patch(
+            "orthos2.data.models.manufacturer.Netbox"
+        ) as mocked_manufacturer_netbox_cls:
+            mocked_devicetype_netbox_cls.get_instance.return_value.fetch_device_type.return_value = (
+                record
+            )
+            mocked_manufacturer_netbox_cls.get_instance.return_value.fetch_manufacturer.return_value = {
+                "id": 99,
+                "name": "AcmeCorp",
+            }
+            device_type = DeviceType.get_or_create_from_netbox(6)
+
+        assert device_type is not None
+        assert device_type.name == "EPYC ROME"
+        assert device_type.netbox_id == 6
+        manufacturer = Manufacturer.objects.get(name="AcmeCorp")
+        assert device_type.manufacturer_id == manufacturer.pk
+        assert manufacturer.netbox_id == 99
+
+    def test_reuses_manufacturer_already_linked_by_netbox_id(self) -> None:
+        existing = Manufacturer.objects.create(
+            name="AMD (renamed locally)", netbox_id=4
+        )
+        with patch("orthos2.data.models.devicetype.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_device_type.return_value = (
+                NETBOX_DEVICETYPE_RECORD
+            )
+            device_type = DeviceType.get_or_create_from_netbox(6)
+
+        assert device_type is not None
+        assert device_type.manufacturer_id == existing.pk
+        assert Manufacturer.objects.filter(netbox_id=4).count() == 1
+
+    def test_links_existing_unlinked_manufacturer_found_by_name(self) -> None:
+        # Seeded by migration 0044_initial_required_data.py, netbox_id=0.
+        existing_amd = Manufacturer.objects.get(name="AMD")
+        assert existing_amd.netbox_id == 0
+
+        with patch(
+            "orthos2.data.models.devicetype.Netbox"
+        ) as mocked_devicetype_netbox_cls, patch(
+            "orthos2.data.models.manufacturer.Netbox"
+        ) as mocked_manufacturer_netbox_cls:
+            mocked_devicetype_netbox_cls.get_instance.return_value.fetch_device_type.return_value = (
+                NETBOX_DEVICETYPE_RECORD
+            )
+            mocked_manufacturer_netbox_cls.get_instance.return_value.fetch_manufacturer.return_value = (
+                NETBOX_MANUFACTURER_RECORD
+            )
+            device_type = DeviceType.get_or_create_from_netbox(6)
+
+        existing_amd.refresh_from_db()
+        assert existing_amd.netbox_id == 4
+        assert device_type is not None
+        assert device_type.manufacturer_id == existing_amd.pk
+        assert Manufacturer.objects.filter(name="AMD").count() == 1
+
+    def test_reuses_devicetype_already_linked_by_netbox_id_without_refetching(
+        self,
+    ) -> None:
+        manufacturer = Manufacturer.objects.create(name="AcmeCorp", netbox_id=4)
+        existing = DeviceType.objects.create(
+            name="EPYC ROME (renamed locally)",
+            manufacturer=manufacturer,
+            netbox_id=6,
+        )
+        with patch("orthos2.data.models.devicetype.Netbox") as mocked_netbox_cls:
+            device_type = DeviceType.get_or_create_from_netbox(6)
+
+        assert device_type is not None
+        assert device_type.pk == existing.pk
+        assert device_type.name == "EPYC ROME (renamed locally)"
+        mocked_netbox_cls.get_instance.return_value.fetch_device_type.assert_not_called()
+
+    def test_links_existing_unlinked_devicetype_found_by_name_and_manufacturer(
+        self,
+    ) -> None:
+        manufacturer = Manufacturer.objects.create(name="AcmeCorp", netbox_id=4)
+        existing = DeviceType.objects.create(
+            name="EPYC ROME", manufacturer=manufacturer
+        )
+        record = {
+            **NETBOX_DEVICETYPE_RECORD,
+            "manufacturer": {"id": 4, "name": "AcmeCorp"},
+        }
+        with patch("orthos2.data.models.devicetype.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_device_type.return_value = (
+                record
+            )
+            device_type = DeviceType.get_or_create_from_netbox(6)
+
+        existing.refresh_from_db()
+        assert existing.netbox_id == 6
+        assert device_type is not None
+        assert device_type.pk == existing.pk
+        assert (
+            DeviceType.objects.filter(
+                manufacturer=manufacturer, name="EPYC ROME"
+            ).count()
+            == 1
+        )
+
+    def test_returns_none_on_404(self) -> None:
+        with patch("orthos2.data.models.devicetype.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_device_type.side_effect = _http_error(
+                404
+            )
+            device_type = DeviceType.get_or_create_from_netbox(999)
+
+        assert device_type is None
+        assert not DeviceType.objects.filter(netbox_id=999).exists()
+
+    def test_reraises_non_404_http_error(self) -> None:
+        with patch("orthos2.data.models.devicetype.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_device_type.side_effect = _http_error(
+                500
+            )
+            with self.assertRaises(HTTPError):
+                DeviceType.get_or_create_from_netbox(6)
+
+    def test_returns_none_when_manufacturer_data_missing(self) -> None:
+        record = {**NETBOX_DEVICETYPE_RECORD, "manufacturer": None}
+        with patch("orthos2.data.models.devicetype.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_device_type.return_value = (
+                record
+            )
+            device_type = DeviceType.get_or_create_from_netbox(6)
+
+        assert device_type is None
+        assert not DeviceType.objects.filter(netbox_id=6).exists()

--- a/orthos2/data/tests/test_machine_devicetype_netbox.py
+++ b/orthos2/data/tests/test_machine_devicetype_netbox.py
@@ -1,0 +1,91 @@
+"""Tests for device_type resolution in Machine.fetch_netbox()."""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from orthos2.data.models import Architecture, DeviceType, Machine, Manufacturer, System
+
+NETBOX_DEVICE_RECORD = {
+    "description": "",
+    "serial": "",
+    "custom_fields": {},
+    "device_type": {
+        "id": 6,
+        "manufacturer": {"id": 4, "name": "AMD"},
+        "model": "EPYC ROME",
+    },
+}
+
+NETBOX_VM_RECORD = {
+    "description": "",
+    "serial": "",
+    "custom_fields": {},
+}
+
+
+class FetchNetboxDeviceTypeTest(TestCase):
+    fixtures = ["orthos2/data/fixtures/tests/test_domain_orthos2test.json"]
+
+    def setUp(self) -> None:
+        self.manufacturer = Manufacturer.objects.create(name="AMD-Local", netbox_id=4)
+        self.device_type = DeviceType.objects.create(
+            name="EPYC ROME", manufacturer=self.manufacturer, netbox_id=6
+        )
+        self.machine = Machine.objects.create(
+            fqdn="testmachine.orthos2.test",
+            system=System.objects.get(name="BareMetal"),
+            architecture=Architecture.objects.get(name="x86_64"),
+            netbox_id=123,
+        )
+
+    def _fetch_netbox(self, netbox_record) -> None:
+        with patch.object(
+            self.machine, "fetch_netbox_record", return_value=netbox_record
+        ), patch("orthos2.data.models.machine.Netbox") as mocked_netbox_cls, patch(
+            "orthos2.data.models.machine.DeviceType.get_or_create_from_netbox"
+        ) as mocked_resolver:
+            mocked_netbox_instance = mocked_netbox_cls.get_instance.return_value
+            mocked_netbox_instance.check_interface_no_mgmt_by_id.return_value = []
+            mocked_netbox_instance.check_interface_mgmt_by_id.return_value = []
+            mocked_resolver.return_value = self.device_type
+            self.machine.fetch_netbox()
+        self._mocked_resolver = mocked_resolver
+
+    def test_resolves_device_type_when_unset(self) -> None:
+        self._fetch_netbox(NETBOX_DEVICE_RECORD)
+
+        self._mocked_resolver.assert_called_once_with(6)
+        self.machine.refresh_from_db()
+        assert self.machine.device_type_id == self.device_type.pk
+
+    def test_skips_resolution_when_already_linked_to_same_device_type(self) -> None:
+        self.machine.device_type = self.device_type
+        self.machine.save()
+
+        self._fetch_netbox(NETBOX_DEVICE_RECORD)
+
+        self._mocked_resolver.assert_not_called()
+
+    def test_reresolves_when_linked_device_type_differs(self) -> None:
+        other_manufacturer = Manufacturer.objects.create(
+            name="Other-Local", netbox_id=5
+        )
+        other_device_type = DeviceType.objects.create(
+            name="Other Model", manufacturer=other_manufacturer, netbox_id=7
+        )
+        self.machine.device_type = other_device_type
+        self.machine.save()
+
+        self._fetch_netbox(NETBOX_DEVICE_RECORD)
+
+        self._mocked_resolver.assert_called_once_with(6)
+        self.machine.refresh_from_db()
+        assert self.machine.device_type_id == self.device_type.pk
+
+    def test_skips_resolution_for_vm_payload_without_device_type(self) -> None:
+        self._fetch_netbox(NETBOX_VM_RECORD)
+
+        self._mocked_resolver.assert_not_called()
+        self.machine.refresh_from_db()
+        assert self.machine.device_type is None

--- a/orthos2/data/tests/test_manufacturer_auto_discovery.py
+++ b/orthos2/data/tests/test_manufacturer_auto_discovery.py
@@ -1,0 +1,106 @@
+"""Tests for Manufacturer.get_or_create_from_netbox()."""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+from requests import HTTPError
+from requests.models import Response
+
+from orthos2.data.models import Manufacturer
+
+NETBOX_MANUFACTURER_RECORD = {
+    "id": 4,
+    "name": "AMD",
+    "slug": "amd",
+    "description": "",
+}
+
+
+def _http_error(status_code: int) -> HTTPError:
+    response = Response()
+    response.status_code = status_code
+    return HTTPError(response=response)
+
+
+class GetOrCreateFromNetboxTest(TestCase):
+    """
+    Migration 0044_initial_required_data.py seeds 28 Manufacturer rows with
+    netbox_id=0, including one named "AMD" - the exact NetBox manufacturer
+    name used here, so the name-fallback/backfill path is exercised against
+    real seed data rather than an artificial collision.
+    """
+
+    def test_returns_none_for_falsy_id(self) -> None:
+        assert Manufacturer.get_or_create_from_netbox(0) is None
+        assert Manufacturer.get_or_create_from_netbox(None) is None
+
+    def test_creates_manufacturer_when_none_exists(self) -> None:
+        record = {**NETBOX_MANUFACTURER_RECORD, "id": 99, "name": "AcmeCorp"}
+        with patch("orthos2.data.models.manufacturer.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_manufacturer.return_value = (
+                record
+            )
+            manufacturer = Manufacturer.get_or_create_from_netbox(99)
+
+        assert manufacturer is not None
+        assert manufacturer.name == "AcmeCorp"
+        assert manufacturer.netbox_id == 99
+
+    def test_reuses_manufacturer_already_linked_by_netbox_id_without_refetching(
+        self,
+    ) -> None:
+        existing = Manufacturer.objects.create(
+            name="AMD (renamed locally)", netbox_id=4
+        )
+        with patch("orthos2.data.models.manufacturer.Netbox") as mocked_netbox_cls:
+            manufacturer = Manufacturer.get_or_create_from_netbox(4)
+
+        assert manufacturer is not None
+        assert manufacturer.pk == existing.pk
+        mocked_netbox_cls.get_instance.return_value.fetch_manufacturer.assert_not_called()
+
+    def test_links_existing_unlinked_manufacturer_found_by_name(self) -> None:
+        # Seeded by migration 0044_initial_required_data.py, netbox_id=0.
+        existing_amd = Manufacturer.objects.get(name="AMD")
+        assert existing_amd.netbox_id == 0
+
+        with patch("orthos2.data.models.manufacturer.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_manufacturer.return_value = (
+                NETBOX_MANUFACTURER_RECORD
+            )
+            manufacturer = Manufacturer.get_or_create_from_netbox(4)
+
+        existing_amd.refresh_from_db()
+        assert existing_amd.netbox_id == 4
+        assert manufacturer is not None
+        assert manufacturer.pk == existing_amd.pk
+        assert Manufacturer.objects.filter(name="AMD").count() == 1
+
+    def test_returns_none_on_404(self) -> None:
+        with patch("orthos2.data.models.manufacturer.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_manufacturer.side_effect = _http_error(
+                404
+            )
+            manufacturer = Manufacturer.get_or_create_from_netbox(999)
+
+        assert manufacturer is None
+        assert not Manufacturer.objects.filter(netbox_id=999).exists()
+
+    def test_reraises_non_404_http_error(self) -> None:
+        with patch("orthos2.data.models.manufacturer.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_manufacturer.side_effect = _http_error(
+                500
+            )
+            with self.assertRaises(HTTPError):
+                Manufacturer.get_or_create_from_netbox(4)
+
+    def test_returns_none_when_name_missing(self) -> None:
+        record = {**NETBOX_MANUFACTURER_RECORD, "name": None}
+        with patch("orthos2.data.models.manufacturer.Netbox") as mocked_netbox_cls:
+            mocked_netbox_cls.get_instance.return_value.fetch_manufacturer.return_value = (
+                record
+            )
+            manufacturer = Manufacturer.get_or_create_from_netbox(4)
+
+        assert manufacturer is None
+        assert not Manufacturer.objects.filter(netbox_id=4).exists()

--- a/orthos2/frontend/forms/addmachine.py
+++ b/orthos2/frontend/forms/addmachine.py
@@ -9,7 +9,7 @@ from django.urls import reverse  # type: ignore
 from django.views.generic.edit import FormView
 from requests import HTTPError
 
-from orthos2.data.models import Architecture, Enclosure, Machine, System
+from orthos2.data.models import Architecture, DeviceType, Enclosure, Machine, System
 from orthos2.utils.netbox import Netbox
 
 
@@ -93,9 +93,11 @@ class AddMachineFormView(FormView):  # type: ignore
     def form_valid(self, form: BaseForm) -> HttpResponse:
         netbox_api = Netbox.get_instance()
         netbox_object_type = form.data["netbox_object_type"]
+        device_type_id = None
         if netbox_object_type == "device":
             netbox_object = safe_fetch_device(netbox_api, form.data["netbox_id"])
             object_name = netbox_object.get("name", "")
+            device_type_id = (netbox_object.get("device_type") or {}).get("id")
             # Try existing enclosure
             try:
                 existing_enclosure = Enclosure.objects.get(name=object_name)
@@ -106,12 +108,17 @@ class AddMachineFormView(FormView):  # type: ignore
                 # Try next objects type
                 pass
         else:
+            # Virtual machines have no device_type in NetBox.
             netbox_object = safe_fetch_vm(netbox_api, form.data["netbox_id"])
             object_name = netbox_object.get("name", "")
         # Try existing machine
         try:
             existing_machine = Machine.objects.get(fqdn=object_name)
             existing_machine.netbox_id = form.data["netbox_id"]
+            if device_type_id:
+                existing_machine.device_type = DeviceType.get_or_create_from_netbox(
+                    device_type_id
+                )
             existing_machine.save()
             self.__machine_pk = existing_machine.pk
             return super().form_valid(form)  # type: ignore
@@ -139,6 +146,10 @@ class AddMachineFormView(FormView):  # type: ignore
         new_machine.architecture = target_arch
         new_machine.system_id = form.data["system"]
         new_machine.netbox_id = form.data["netbox_id"]
+        if device_type_id:
+            new_machine.device_type = DeviceType.get_or_create_from_netbox(
+                device_type_id
+            )
         try:
             new_machine.save()
         except ValidationError as e:

--- a/orthos2/frontend/templates/frontend/dailytasks/detail/actions.html
+++ b/orthos2/frontend/templates/frontend/dailytasks/detail/actions.html
@@ -28,6 +28,21 @@
   {% endif %}
 </form>
 <br />
+<form
+  method="post"
+  action="{% url 'frontend:dailytask_toggle_running' dailytask.pk %}"
+  class="w-100"
+>
+  {% csrf_token %}
+  <button
+    type="submit"
+    class="btn btn-danger btn-sm w-100"
+    title="Recovery for a task stuck as running because the taskmanager was killed/restarted mid-execution"
+  >
+    Force Toggle "Running" Flag
+  </button>
+</form>
+<br />
 <div class="btn-group-vertical d-flex">
   <a
     class="btn btn-danger btn-sm"

--- a/orthos2/frontend/templates/frontend/singletasks/detail/actions.html
+++ b/orthos2/frontend/templates/frontend/singletasks/detail/actions.html
@@ -12,6 +12,21 @@
   >
 </div>
 <br />
+<form
+  method="post"
+  action="{% url 'frontend:singletask_toggle_running' singletask.pk %}"
+  class="w-100"
+>
+  {% csrf_token %}
+  <button
+    type="submit"
+    class="btn btn-danger btn-sm w-100"
+    title="Recovery for a task stuck as running because the taskmanager was killed/restarted mid-execution"
+  >
+    Force Toggle "Running" Flag
+  </button>
+</form>
+<br />
 <div class="btn-group-vertical d-flex">
   <a
     class="btn btn-danger btn-sm"

--- a/orthos2/frontend/tests/admin/test_addmachine_devicetype.py
+++ b/orthos2/frontend/tests/admin/test_addmachine_devicetype.py
@@ -1,0 +1,108 @@
+"""
+Tests for device_type resolution in the "Add via NetBox ID" flow
+(AddMachineFormView.form_valid()).
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from orthos2.data.models import Architecture, DeviceType, Machine, Manufacturer, System
+
+NETBOX_DEVICE_RECORD = {
+    "name": "newmachine.orthos2.test",
+    "custom_fields": {"arch": "x86_64"},
+    "device_type": {
+        "id": 6,
+        "manufacturer": {"id": 4, "name": "AMD"},
+        "model": "EPYC ROME",
+    },
+}
+
+NETBOX_VM_RECORD = {
+    "name": "newvm.orthos2.test",
+    "custom_fields": {"arch": "x86_64"},
+}
+
+
+class AddMachineDeviceTypeTest(TestCase):
+    fixtures = [
+        "orthos2/frontend/tests/user/fixtures/users.json",
+        "orthos2/data/fixtures/tests/test_domain_orthos2test.json",
+    ]
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.get(username="superuser")
+        self.system = System.objects.get(name="BareMetal")
+        self.manufacturer = Manufacturer.objects.create(name="AMD-Local", netbox_id=4)
+        self.device_type = DeviceType.objects.create(
+            name="EPYC ROME", manufacturer=self.manufacturer, netbox_id=6
+        )
+
+    def _post_add_machine(self, netbox_object_type: str):
+        self.client.force_login(self.superuser)
+        return self.client.post(
+            reverse("frontend:machine_add"),
+            {
+                "netbox_id": "123",
+                "system": self.system.pk,
+                "netbox_object_type": netbox_object_type,
+            },
+        )
+
+    def test_new_device_gets_device_type_resolved(self) -> None:
+        with patch(
+            "orthos2.frontend.forms.addmachine.Netbox"
+        ) as mocked_netbox_cls, patch(
+            "orthos2.frontend.forms.addmachine.DeviceType.get_or_create_from_netbox"
+        ) as mocked_resolver:
+            mocked_netbox_cls.get_instance.return_value.fetch_device.return_value = (
+                NETBOX_DEVICE_RECORD
+            )
+            mocked_resolver.return_value = self.device_type
+            response = self._post_add_machine("device")
+
+        assert response.status_code == 302
+        mocked_resolver.assert_called_once_with(6)
+        machine = Machine.objects.get(fqdn="newmachine.orthos2.test")
+        assert machine.device_type_id == self.device_type.pk
+
+    def test_existing_machine_matched_by_fqdn_gets_device_type_updated(self) -> None:
+        existing_machine = Machine.objects.create(
+            fqdn="newmachine.orthos2.test",
+            system=self.system,
+            architecture=Architecture.objects.get(name="x86_64"),
+        )
+        with patch(
+            "orthos2.frontend.forms.addmachine.Netbox"
+        ) as mocked_netbox_cls, patch(
+            "orthos2.frontend.forms.addmachine.DeviceType.get_or_create_from_netbox"
+        ) as mocked_resolver:
+            mocked_netbox_cls.get_instance.return_value.fetch_device.return_value = (
+                NETBOX_DEVICE_RECORD
+            )
+            mocked_resolver.return_value = self.device_type
+            response = self._post_add_machine("device")
+
+        assert response.status_code == 302
+        mocked_resolver.assert_called_once_with(6)
+        existing_machine.refresh_from_db()
+        assert existing_machine.device_type_id == self.device_type.pk
+
+    def test_vm_object_type_skips_device_type_resolution(self) -> None:
+        with patch(
+            "orthos2.frontend.forms.addmachine.Netbox"
+        ) as mocked_netbox_cls, patch(
+            "orthos2.frontend.forms.addmachine.DeviceType.get_or_create_from_netbox"
+        ) as mocked_resolver:
+            mocked_netbox_cls.get_instance.return_value.fetch_vm.return_value = (
+                NETBOX_VM_RECORD
+            )
+            response = self._post_add_machine("vm")
+
+        assert response.status_code == 302
+        mocked_resolver.assert_not_called()
+        machine = Machine.objects.get(fqdn="newvm.orthos2.test")
+        assert machine.device_type is None

--- a/orthos2/frontend/tests/admin/test_dailytask_views.py
+++ b/orthos2/frontend/tests/admin/test_dailytask_views.py
@@ -270,3 +270,61 @@ class DailyTaskSwitchViewTest(TestCase):
         url = reverse("frontend:dailytask_switch", kwargs={"id": self.dailytask.pk})
         response = self.client.post(url, {"action": "frobnicate"})
         assert response.status_code == 404
+
+
+class DailyTaskToggleRunningViewTest(TestCase):
+    fixtures = ["orthos2/frontend/tests/user/fixtures/users.json"]
+
+    def setUp(self) -> None:
+        self.dailytask = DailyTask.objects.create(
+            name="AcmeDailyTask",
+            module="acme.module",
+            arguments="[[], {}]",
+            running=True,
+        )
+
+    def test_unauthenticated_post_redirects_to_login(self) -> None:
+        url = reverse(
+            "frontend:dailytask_toggle_running", kwargs={"id": self.dailytask.pk}
+        )
+        response = self.client.post(url)
+        assert response.status_code == 302
+        assert "login" in response.url.lower()  # type: ignore[attr-defined]
+
+    def test_regular_user_post_is_forbidden(self) -> None:
+        self.client.force_login(User.objects.get(username="user"))
+        url = reverse(
+            "frontend:dailytask_toggle_running", kwargs={"id": self.dailytask.pk}
+        )
+        response = self.client.post(url)
+        assert response.status_code == 403
+
+    def test_get_is_not_allowed(self) -> None:
+        self.client.force_login(User.objects.get(username="superuser"))
+        url = reverse(
+            "frontend:dailytask_toggle_running", kwargs={"id": self.dailytask.pk}
+        )
+        response = self.client.get(url)
+        assert response.status_code == 405
+
+    def test_superuser_post_flips_running_from_true_to_false(self) -> None:
+        self.client.force_login(User.objects.get(username="superuser"))
+        url = reverse(
+            "frontend:dailytask_toggle_running", kwargs={"id": self.dailytask.pk}
+        )
+        response = self.client.post(url)
+        assert response.status_code == 302
+        self.dailytask.refresh_from_db()
+        assert self.dailytask.running is False
+
+    def test_superuser_post_flips_running_from_false_to_true(self) -> None:
+        self.dailytask.running = False
+        self.dailytask.save()
+        self.client.force_login(User.objects.get(username="superuser"))
+        url = reverse(
+            "frontend:dailytask_toggle_running", kwargs={"id": self.dailytask.pk}
+        )
+        response = self.client.post(url)
+        assert response.status_code == 302
+        self.dailytask.refresh_from_db()
+        assert self.dailytask.running is True

--- a/orthos2/frontend/tests/admin/test_singletask_views.py
+++ b/orthos2/frontend/tests/admin/test_singletask_views.py
@@ -216,3 +216,58 @@ class DeleteSingleTaskViewTest(TestCase):
         response = self.client.post(url)
         assert response.status_code == 403
         assert SingleTask.objects.filter(pk=self.singletask.pk).exists()
+
+
+class SingleTaskToggleRunningViewTest(TestCase):
+    fixtures = ["orthos2/frontend/tests/user/fixtures/users.json"]
+
+    def setUp(self) -> None:
+        self.singletask = SingleTask.objects.create(
+            name="AcmeTask", module="acme.module", arguments="[[], {}]", running=True
+        )
+
+    def test_unauthenticated_post_redirects_to_login(self) -> None:
+        url = reverse(
+            "frontend:singletask_toggle_running", kwargs={"id": self.singletask.pk}
+        )
+        response = self.client.post(url)
+        assert response.status_code == 302
+        assert "login" in response.url.lower()  # type: ignore[attr-defined]
+
+    def test_regular_user_post_is_forbidden(self) -> None:
+        self.client.force_login(User.objects.get(username="user"))
+        url = reverse(
+            "frontend:singletask_toggle_running", kwargs={"id": self.singletask.pk}
+        )
+        response = self.client.post(url)
+        assert response.status_code == 403
+
+    def test_get_is_not_allowed(self) -> None:
+        self.client.force_login(User.objects.get(username="superuser"))
+        url = reverse(
+            "frontend:singletask_toggle_running", kwargs={"id": self.singletask.pk}
+        )
+        response = self.client.get(url)
+        assert response.status_code == 405
+
+    def test_superuser_post_flips_running_from_true_to_false(self) -> None:
+        self.client.force_login(User.objects.get(username="superuser"))
+        url = reverse(
+            "frontend:singletask_toggle_running", kwargs={"id": self.singletask.pk}
+        )
+        response = self.client.post(url)
+        assert response.status_code == 302
+        self.singletask.refresh_from_db()
+        assert self.singletask.running is False
+
+    def test_superuser_post_flips_running_from_false_to_true(self) -> None:
+        self.singletask.running = False
+        self.singletask.save()
+        self.client.force_login(User.objects.get(username="superuser"))
+        url = reverse(
+            "frontend:singletask_toggle_running", kwargs={"id": self.singletask.pk}
+        )
+        response = self.client.post(url)
+        assert response.status_code == 302
+        self.singletask.refresh_from_db()
+        assert self.singletask.running is True

--- a/orthos2/frontend/urls.py
+++ b/orthos2/frontend/urls.py
@@ -544,6 +544,11 @@ urlpatterns = [
         views.DeleteSingleTask.as_view(),
         name="delete_singletask",
     ),
+    path(
+        "singletask/<int:id>/toggle-running/",
+        views.singletask_toggle_running,
+        name="singletask_toggle_running",
+    ),
     # Daily Tasks
     path("dailytasks", views.DailyTaskListView.as_view(), name="dailytasks"),
     re_path(
@@ -571,6 +576,11 @@ urlpatterns = [
         "dailytask/<int:id>/switch/",
         views.dailytask_switch,
         name="dailytask_switch",
+    ),
+    path(
+        "dailytask/<int:id>/toggle-running/",
+        views.dailytask_toggle_running,
+        name="dailytask_toggle_running",
     ),
     # Remote Power Types
     path(

--- a/orthos2/frontend/views/__init__.py
+++ b/orthos2/frontend/views/__init__.py
@@ -31,6 +31,7 @@ from .dailytask import (
     dailytask_detail,
     dailytask_execute,
     dailytask_switch,
+    dailytask_toggle_running,
 )
 from .devicetype import (
     DeleteDeviceType,
@@ -171,6 +172,7 @@ from .singletask import (
     SingleTaskDetailedEdit,
     SingleTaskListView,
     singletask_detail,
+    singletask_toggle_running,
 )
 from .statistics import statistics
 from .system import (
@@ -329,6 +331,7 @@ __all__ = [
     "SingleTaskDetailedEdit",
     "DeleteSingleTask",
     "singletask_detail",
+    "singletask_toggle_running",
     "DailyTaskListView",
     "NewDailyTask",
     "DailyTaskDetailedEdit",
@@ -336,6 +339,7 @@ __all__ = [
     "dailytask_detail",
     "dailytask_execute",
     "dailytask_switch",
+    "dailytask_toggle_running",
     "RemotePowerTypeListView",
     "NewRemotePowerType",
     "RemotePowerTypeDetailedEdit",

--- a/orthos2/frontend/views/dailytask.py
+++ b/orthos2/frontend/views/dailytask.py
@@ -130,3 +130,24 @@ def dailytask_switch(request: HttpRequest, id: int) -> HttpResponseRedirect:
     messages.info(request, "Successfully {}d task '{}'.".format(action, task.name))
 
     return redirect("frontend:dailytask_detail", id=task.pk)
+
+
+@require_POST
+@login_required
+def dailytask_toggle_running(request: HttpRequest, id: int) -> HttpResponseRedirect:
+    """
+    Forcibly flip the 'running' flag - recovery for a task stuck as running
+    because the taskmanager process was killed/restarted mid-execution.
+    """
+    if not request.user.is_superuser:  # type: ignore
+        raise PermissionDenied
+
+    task = get_object_or_404(DailyTask, pk=id)
+    task.running = not task.running
+    task.save()
+    messages.warning(
+        request,
+        "Forced 'running' flag of task '{}' to {}.".format(task.name, task.running),
+    )
+
+    return redirect("frontend:dailytask_detail", id=task.pk)

--- a/orthos2/frontend/views/singletask.py
+++ b/orthos2/frontend/views/singletask.py
@@ -4,11 +4,13 @@ All views that are under "/singletasks".
 
 from typing import Any, Dict
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.http import Http404, HttpRequest, HttpResponse
-from django.shortcuts import render
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
+from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 
 from orthos2.frontend.forms.task import SingleTaskForm
@@ -79,3 +81,24 @@ def singletask_detail(request: HttpRequest, id: int) -> HttpResponse:
         "frontend/singletasks/detail/overview.html",
         {"singletask": singletask, "title": "Single Task {}".format(singletask.name)},
     )
+
+
+@require_POST
+@login_required
+def singletask_toggle_running(request: HttpRequest, id: int) -> HttpResponseRedirect:
+    """
+    Forcibly flip the 'running' flag - recovery for a task stuck as running
+    because the taskmanager process was killed/restarted mid-execution.
+    """
+    if not request.user.is_superuser:  # type: ignore
+        raise PermissionDenied
+
+    task = get_object_or_404(SingleTask, pk=id)
+    task.running = not task.running
+    task.save()
+    messages.warning(
+        request,
+        "Forced 'running' flag of task '{}' to {}.".format(task.name, task.running),
+    )
+
+    return redirect("frontend:singletask_detail", id=task.pk)

--- a/orthos2/taskmanager/executer.py
+++ b/orthos2/taskmanager/executer.py
@@ -70,6 +70,34 @@ class TaskExecuter(Thread):
             singletask.save()
             self.queue[singletask.priority].put(singletask)
 
+    def reset_stale_running_tasks(self) -> None:
+        """
+        Clear the 'running' flag left behind on tasks that were mid-execution
+        when the taskmanager process last stopped (crash, restart, kill -9).
+        This process just started and tracks no threads yet, so any task
+        still marked running in the database is necessarily stale, not
+        actually in progress.
+        """
+        stale_daily = DailyTask.objects.filter(running=True)
+        stale_daily_count = stale_daily.count()
+        if stale_daily_count:
+            logger.warning(
+                "Resetting %d daily task(s) stuck as running from a previous "
+                "taskmanager run.",
+                stale_daily_count,
+            )
+            stale_daily.update(running=False)
+
+        stale_single = SingleTask.objects.filter(running=True)
+        stale_single_count = stale_single.count()
+        if stale_single_count:
+            logger.warning(
+                "Resetting %d single task(s) stuck as running from a previous "
+                "taskmanager run.",
+                stale_single_count,
+            )
+            stale_single.update(running=False)
+
     def reset_daily_task(self, hash: str) -> None:
         """Reset daily task and unset 'running' field."""
         try:
@@ -101,6 +129,7 @@ class TaskExecuter(Thread):
 
     def run(self) -> None:
         """Main thread function."""
+        self.reset_stale_running_tasks()
         running_threads: Dict[str, Tuple[Thread, "Task"]] = {}
         while not self._stop_execution:
             queue = None

--- a/orthos2/taskmanager/fixtures/dailytasks.json
+++ b/orthos2/taskmanager/fixtures/dailytasks.json
@@ -46,5 +46,21 @@
       "executed_at": "2021-06-23T22:01:10.967Z",
       "enabled": true
     }
+  },
+  {
+    "model": "taskmanager.dailytask",
+    "pk": null,
+    "fields": {
+      "name": "DailyManufacturerDeviceTypeCleanup",
+      "module": "orthos2.taskmanager.tasks.daily",
+      "arguments": "[[], {}]",
+      "hash": "24b05a7844bb8565363920670e1a83331ecb087d",
+      "priority": 10,
+      "running": false,
+      "updated": "2026-08-22T00:00:00.000Z",
+      "created": "2026-08-22T00:00:00.000Z",
+      "executed_at": "2026-08-22T00:00:00.000Z",
+      "enabled": true
+    }
   }
 ]

--- a/orthos2/taskmanager/tasks/__init__.py
+++ b/orthos2/taskmanager/tasks/__init__.py
@@ -9,6 +9,7 @@ from .daily import (
     DailyCheckForPrimaryNetwork,
     DailyCheckReservationExpirations,
     DailyMachineChecks,
+    DailyManufacturerDeviceTypeCleanup,
     DailyNetboxFetch,
 )
 from .machinetasks import MachineCheck, RegenerateMOTD
@@ -50,6 +51,7 @@ __all__ = [
     "DailyCheckForPrimaryNetwork",
     "DailyCheckReservationExpirations",
     "DailyMachineChecks",
+    "DailyManufacturerDeviceTypeCleanup",
     "DailyNetboxFetch",
     "DeactivateSerialOverLan",
     "MachineCheck",

--- a/orthos2/taskmanager/tasks/daily.py
+++ b/orthos2/taskmanager/tasks/daily.py
@@ -90,3 +90,21 @@ class DailyNetboxFetch(Task):
         TaskManager.add(tasks.NetboxFetchNetworkInterface())
         TaskManager.add(tasks.NetboxFetchBMC())
         TaskManager.add(tasks.NetboxFetchRemotePowerDevice())
+
+
+class DailyManufacturerDeviceTypeCleanup(Task):
+    """
+    Delete Manufacturer/DeviceType rows no longer referenced by any Machine
+    or Enclosure.
+    """
+
+    def execute(self) -> None:
+        """
+        Execute the task.
+        """
+        from orthos2.data.models import DeviceType, Manufacturer
+
+        # DeviceType first: DeviceType.manufacturer is on_delete=CASCADE, so a
+        # Manufacturer only becomes orphaned once all its DeviceTypes are gone.
+        DeviceType.objects.filter(machine__isnull=True, enclosure__isnull=True).delete()
+        Manufacturer.objects.filter(devicetype__isnull=True).delete()

--- a/orthos2/taskmanager/tasks/registry.py
+++ b/orthos2/taskmanager/tasks/registry.py
@@ -25,6 +25,7 @@ from orthos2.taskmanager.tasks.daily import (
     DailyCheckForPrimaryNetwork,
     DailyCheckReservationExpirations,
     DailyMachineChecks,
+    DailyManufacturerDeviceTypeCleanup,
     DailyNetboxFetch,
 )
 from orthos2.taskmanager.tasks.machinetasks import MachineCheck, RegenerateMOTD
@@ -63,6 +64,7 @@ DAILY_TASK_CLASSES: List[Type[Task]] = [
     DailyCheckReservationExpirations,
     DailyCheckForPrimaryNetwork,
     DailyNetboxFetch,
+    DailyManufacturerDeviceTypeCleanup,
 ]
 """
 Tasks intended to run on a recurring daily schedule (see `orthos2.taskmanager.tasks.daily`) -

--- a/orthos2/taskmanager/tests/test_daily_manufacturer_devicetype_cleanup.py
+++ b/orthos2/taskmanager/tests/test_daily_manufacturer_devicetype_cleanup.py
@@ -1,0 +1,85 @@
+"""Tests for DailyManufacturerDeviceTypeCleanup."""
+
+from django.test import TestCase
+
+from orthos2.data.models import (
+    Architecture,
+    DeviceType,
+    Enclosure,
+    Machine,
+    Manufacturer,
+    System,
+)
+from orthos2.taskmanager.tasks.daily import DailyManufacturerDeviceTypeCleanup
+
+
+class DailyManufacturerDeviceTypeCleanupTest(TestCase):
+    fixtures = ["orthos2/data/fixtures/tests/test_domain_orthos2test.json"]
+
+    def setUp(self) -> None:
+        self.manufacturer = Manufacturer.objects.create(name="AcmeCorp")
+
+    def test_deletes_devicetype_referenced_by_nothing(self) -> None:
+        DeviceType.objects.create(name="Unused", manufacturer=self.manufacturer)
+
+        DailyManufacturerDeviceTypeCleanup().execute()
+
+        assert not DeviceType.objects.filter(name="Unused").exists()
+
+    def test_keeps_devicetype_referenced_by_machine(self) -> None:
+        device_type = DeviceType.objects.create(
+            name="InUse", manufacturer=self.manufacturer
+        )
+        Machine.objects.create(
+            fqdn="testmachine.orthos2.test",
+            system=System.objects.get(name="BareMetal"),
+            architecture=Architecture.objects.get(name="x86_64"),
+            device_type=device_type,
+        )
+
+        DailyManufacturerDeviceTypeCleanup().execute()
+
+        assert DeviceType.objects.filter(pk=device_type.pk).exists()
+
+    def test_keeps_devicetype_referenced_by_enclosure(self) -> None:
+        device_type = DeviceType.objects.create(
+            name="InUse", manufacturer=self.manufacturer
+        )
+        Enclosure.objects.create(name="testenclosure", device_type=device_type)
+
+        DailyManufacturerDeviceTypeCleanup().execute()
+
+        assert DeviceType.objects.filter(pk=device_type.pk).exists()
+
+    def test_deletes_manufacturer_with_no_devicetypes(self) -> None:
+        DailyManufacturerDeviceTypeCleanup().execute()
+
+        assert not Manufacturer.objects.filter(pk=self.manufacturer.pk).exists()
+
+    def test_keeps_manufacturer_with_a_remaining_devicetype(self) -> None:
+        device_type = DeviceType.objects.create(
+            name="InUse", manufacturer=self.manufacturer
+        )
+        Machine.objects.create(
+            fqdn="testmachine.orthos2.test",
+            system=System.objects.get(name="BareMetal"),
+            architecture=Architecture.objects.get(name="x86_64"),
+            device_type=device_type,
+        )
+
+        DailyManufacturerDeviceTypeCleanup().execute()
+
+        assert Manufacturer.objects.filter(pk=self.manufacturer.pk).exists()
+
+    def test_manufacturer_orphaned_by_this_same_run_is_also_deleted(self) -> None:
+        """
+        DeviceType cleanup must run before Manufacturer cleanup: a
+        Manufacturer whose only DeviceType gets deleted in this same
+        execute() call should be deleted too, not left behind for the next
+        run.
+        """
+        DeviceType.objects.create(name="Unused", manufacturer=self.manufacturer)
+
+        DailyManufacturerDeviceTypeCleanup().execute()
+
+        assert not Manufacturer.objects.filter(pk=self.manufacturer.pk).exists()

--- a/orthos2/taskmanager/tests/test_executer.py
+++ b/orthos2/taskmanager/tests/test_executer.py
@@ -1,0 +1,56 @@
+"""Tests for TaskExecuter.reset_stale_running_tasks()."""
+
+from django.test import TestCase
+
+from orthos2.taskmanager.executer import TaskExecuter
+from orthos2.taskmanager.models import DailyTask, SingleTask
+
+
+class ResetStaleRunningTasksTest(TestCase):
+    def test_resets_stale_running_daily_task(self) -> None:
+        task = DailyTask.objects.create(
+            name="DailyMachineChecks",
+            module="orthos2.taskmanager.tasks.daily",
+            running=True,
+        )
+
+        TaskExecuter().reset_stale_running_tasks()
+
+        task.refresh_from_db()
+        assert not task.running
+
+    def test_leaves_non_running_daily_task_alone(self) -> None:
+        task = DailyTask.objects.create(
+            name="DailyMachineChecks",
+            module="orthos2.taskmanager.tasks.daily",
+            running=False,
+        )
+
+        TaskExecuter().reset_stale_running_tasks()
+
+        task.refresh_from_db()
+        assert not task.running
+
+    def test_resets_stale_running_single_task(self) -> None:
+        task = SingleTask.objects.create(
+            name="MachineCheck",
+            module="orthos2.taskmanager.tasks.machinetasks",
+            running=True,
+        )
+
+        TaskExecuter().reset_stale_running_tasks()
+
+        task.refresh_from_db()
+        assert not task.running
+
+    def test_leaves_non_running_single_task_alone(self) -> None:
+        task = SingleTask.objects.create(
+            name="MachineCheck",
+            module="orthos2.taskmanager.tasks.machinetasks",
+            running=False,
+        )
+
+        TaskExecuter().reset_stale_running_tasks()
+
+        task.refresh_from_db()
+        assert not task.running


### PR DESCRIPTION
To enable automatic creation and deletion of Manufacturers and Device Types, Orthos 2 is now capable of creating them during device import and on a "Fetch NetBox" task. Furthermore, they get automatically cleaned up after the last machine or enclosure stops referencing them.

Lastly, this PR contains a bugfix for the TaskManager to clear stale tasks both automatically on startup and manually with a "Danger"-colored button.